### PR TITLE
Update button component previews

### DIFF
--- a/components/02-components/buttons/01-basic/basic.html
+++ b/components/02-components/buttons/01-basic/basic.html
@@ -1,18 +1,15 @@
-<div class="slab slab--{{modifier}}" style="padding: 2rem">
+<div class="slab slab--{{modifier}}" style="padding: 1rem 2rem">
   <div>Standard:</div>
-  <button class="button--standard">Basic button</button>
-  <button class="is-active button--standard">Active button</button>
+  <button class="button--standard" style="margin-right: 2rem">Basic button</button>
   <button class="is-disabled button--standard">Inactive button</button>
 </div>
-<div class="slab slab--{{modifier}}" style="padding: 2rem">
+<div class="slab slab--{{modifier}}" style="padding: 1rem 2rem">
   <div>Call to action:</div>
-  <button class="button--cta{{button}}">Basic button</button>
-  <button class="is-active button--cta{{button}}">Active button</button>
+  <button class="button--cta{{button}}" style="margin-right: 2rem">Basic button</button>
   <button class="is-disabled button--cta{{button}}">Inactive button</button>
 </div>
-<div class="slab slab--{{modifier}}" style="padding: 2rem">
+<div class="slab slab--{{modifier}}" style="padding: 1rem 2rem">
   <div>Alternate:</div>
-  <button class="button--alt{{button}}">Basic button</button>
-  <button class="is-active button--alt{{button}}">Active button</button>
+  <button class="button--alt{{button}}" style="margin-right: 2rem">Basic button</button>
   <button class="is-disabled button--alt{{button}}">Inactive button</button>
 </div>

--- a/components/02-components/buttons/02-buttons-with-icons/buttons-with-icons.html
+++ b/components/02-components/buttons/02-buttons-with-icons/buttons-with-icons.html
@@ -1,122 +1,55 @@
-<div class="slab slab--neutral" style="padding: 1rem 2rem">
-  Browse button: For links to the datatable view
-  <div style="padding-bottom: 10px;">
-    <button class="button--standard button--browse">Button</button>
-    <button class="button--cta button--browse">Button</button>
-    <button class="button--alt button--browse">Button</button>
-    <button class="button--cta-primary button--browse">Button</button>
-    <button class="button--alt-primary button--browse">Button</button>
-    <button class="button--cta-secondary button--browse">Button</button>
-    <button class="button--alt-secondary button--browse">Button</button>
+<div class="slab" style="padding: 1rem 2rem">
+  <div>Browse button: For links to the datatable view</div>
+  <button class="button--standard button--browse" style="margin-right: 2rem">Button</button>
+
+  <div style="margin-top: 2rem">Document button: for opening documents</div>
+  <button class="button--standard button--document" style="margin-right: 2rem">Button</button>
+
+  <div style="margin-top: 2rem">List button: to show a list view</div>
+  <button class="button--standard button--list" style="margin-right: 2rem">Button</button>
+
+  <div style="margin-top: 2rem">Map button: to see a map view</div>
+  <button class="button--standard button--map" style="margin-right: 2rem">Button</button>
+
+  <div style="margin-top: 2rem">Search button: search with text</div>
+  <button class="button--standard button--search--text" style="margin-right: 2rem">Button</button>
+
+  <div style="margin-top: 2rem">Subscribe button: for subscribing to calendar updates in different formats</div>
+  <button class="button--standard button--subscribe" style="margin-right: 2rem">Button</button>
+  <div class="export-widget">
+  <div class="dropdown">
+    <button class="button button--standard dropdown__button button--subscribe">Subscribe</button>
+  </div>
   </div>
 
-  Document button
-  <div style="padding-bottom: 10px;">
-    <button class="button--standard button--document">Button</button>
-    <button class="button--cta button--document">Button</button>
-    <button class="button--alt button--document">Button</button>
-    <button class="button--cta-primary button--document">Button</button>
-    <button class="button--alt-primary button--document">Button</button>
-    <button class="button--cta-secondary button--document">Button</button>
-    <button class="button--alt-secondary button--document">Button</button>
+  <div style="margin-top: 2rem">Download button: to initiate a download with a choice of formats</div>
+  <button class="button--standard button--download" style="margin-right: 2rem">Button</button>
+  <div class="export-widget">
+  <div class="dropdown">
+    <button class="button button--standard dropdown__button button--download--dropdown">Download</button>
+  </div>
   </div>
 
-  Download button
-  <div style="padding-bottom: 10px;">
-    <button class="button--standard button--download">Button</button>
-    <button class="button--cta button--download">Button</button>
-    <button class="button--alt button--download">Button</button>
-    <button class="button--cta-primary button--download">Button</button>
-    <button class="button--alt-primary button--download">Button</button>
-    <button class="button--cta-secondary button--download">Button</button>
-    <button class="button--alt-secondary button--download">Button</button>
+  <div style="margin-top: 2rem">Add to calendar button</div>
+  <button class="button--standard button--add-calendar" style="margin-right: 2rem">Button</button>
+  <div class="export-widget">
+    <div class="dropdown">
+      <button class="button--standard dropdown__button dropdown__button--mini button--add-calendar--mini"><span class="u-visually-hidden">Download calendar</span></button>
+    </div>
   </div>
 
-  List button: list view
-  <div style="padding-bottom: 10px;">
-    <button class="button--standard button--list">Button</button>
-    <button class="button--cta button--list">Button</button>
-    <button class="button--alt button--list">Button</button>
-    <button class="button--cta-primary button--list">Button</button>
-    <button class="button--alt-primary button--list">Button</button>
-    <button class="button--cta-secondary button--list">Button</button>
-    <button class="button--alt-secondary button--list">Button</button>
-  </div>
+  <div style="margin-top: 2rem">Two candidates button: toggle two-candidate view on map comparison</div>
+  <button class="button--standard button--two-candidates" style="margin-right: 2rem">Button</button>
 
-  Map button
-  <div style="padding-bottom: 10px;">
-    <button class="button--standard button--map">Button</button>
-    <button class="button--cta button--map">Button</button>
-    <button class="button--alt button--map">Button</button>
-    <button class="button--cta-primary button--map">Button</button>
-    <button class="button--alt-primary button--map">Button</button>
-    <button class="button--cta-secondary button--map">Button</button>
-    <button class="button--alt-secondary button--map">Button</button>
-  </div>
+  <div style="margin-top: 2rem">Back button</div>
+  <button class="button--standard button--back" style="margin-right: 2rem">Button</button>
 
-  Search button: search with text
-  <div style="padding-bottom: 10px;">
-    <button class="button--standard button--search--text">Button</button>
-    <button class="button--cta button--search--text">Button</button>
-    <button class="button--alt button--search--text">Button</button>
-    <button class="button--cta-primary button--search--text">Button</button>
-    <button class="button--alt-primary button--search--text">Button</button>
-    <button class="button--cta-secondary button--search--text">Button</button>
-    <button class="button--alt-secondary button--search--text">Button</button>
-  </div>
+  <div style="margin-top: 2rem">Go button: to initiate the next step in a sequence</div>
+  <button class="button--standard button--go" style="margin-right: 2rem">Go</button>
 
-  Subscribe button
-  <div style="padding-bottom: 10px;">
-    <button class="button--standard button--subscribe">Button</button>
-    <button class="button--cta button--subscribe">Button</button>
-    <button class="button--alt button--subscribe">Button</button>
-    <button class="button--cta-primary button--subscribe">Button</button>
-    <button class="button--alt-primary button--subscribe">Button</button>
-    <button class="button--cta-secondary button--subscribe">Button</button>
-    <button class="button--alt-secondary button--subscribe">Button</button>
-  </div>
+  <div style="margin-top: 2rem">Export button: for exporting files</div>
+  <button class="button--standard button--export" style="margin-right: 2rem">Button</button>
 
-  Two candidates button: toggle two-candidate view on map comparison
-  <div style="padding-bottom: 10px;">
-    <button class="button--standard button--two-candidates">Button</button>
-    <button class="button--cta button--two-candidates">Button</button>
-    <button class="button--alt button--two-candidates">Button</button>
-    <button class="button--cta-primary button--two-candidates">Button</button>
-    <button class="button--alt-primary button--two-candidates">Button</button>
-    <button class="button--cta-secondary button--two-candidates">Button</button>
-    <button class="button--alt-secondary button--two-candidates">Button</button>
-  </div>
-
-  Export button
-  <div style="padding-bottom: 10px;">
-    <button class="button--standard button--export">Button</button>
-    <button class="button--cta button--export">Button</button>
-    <button class="button--alt button--export">Button</button>
-    <button class="button--cta-primary button--export">Button</button>
-    <button class="button--alt-primary button--export">Button</button>
-    <button class="button--cta-secondary button--export">Button</button>
-    <button class="button--alt-secondary button--export">Button</button>
-  </div>
-
-  Go button
-  <div style="padding-bottom: 10px;">
-    <button class="button--standard button--go">Button</button>
-    <button class="button--cta button--go">Button</button>
-    <button class="button--alt button--go">Button</button>
-    <button class="button--cta-primary button--go">Button</button>
-    <button class="button--alt-primary button--go">Button</button>
-    <button class="button--cta-secondary button--go">Button</button>
-    <button class="button--alt-secondary button--go">Button</button>
-  </div>
-
-  Table button
-  <div style="padding-bottom: 10px;">
-    <button class="button--standard button--table">Button</button>
-    <button class="button--cta button--table">Button</button>
-    <button class="button--alt button--table">Button</button>
-    <button class="button--cta-primary button--table">Button</button>
-    <button class="button--alt-primary button--table">Button</button>
-    <button class="button--cta-secondary button--table">Button</button>
-    <button class="button--alt-secondary button--table">Button</button>
-  </div>
+  <div style="margin-top: 2rem">Table button</div>
+  <button class="button--standard button--table" style="margin-right: 2rem">Button</button>
 </div>

--- a/components/02-components/buttons/02-buttons-with-icons/buttons-with-icons.html
+++ b/components/02-components/buttons/02-buttons-with-icons/buttons-with-icons.html
@@ -15,28 +15,42 @@
   <button class="button--standard button--search--text" style="margin-right: 2rem">Button</button>
 
   <div style="margin-top: 2rem">Subscribe button: for subscribing to calendar updates in different formats</div>
-  <button class="button--standard button--subscribe" style="margin-right: 2rem">Button</button>
-  <div class="export-widget">
-  <div class="dropdown">
-    <button class="button button--standard dropdown__button button--subscribe">Subscribe</button>
-  </div>
-  </div>
-
-  <div style="margin-top: 2rem">Download button: to initiate a download with a choice of formats</div>
-  <button class="button--standard button--download" style="margin-right: 2rem">Button</button>
-  <div class="export-widget">
-  <div class="dropdown">
-    <button class="button button--standard dropdown__button button--download--dropdown">Download</button>
-  </div>
-  </div>
-
-  <div style="margin-top: 2rem">Add to calendar button</div>
-  <button class="button--standard button--add-calendar" style="margin-right: 2rem">Button</button>
-  <div class="export-widget">
-    <div class="dropdown">
-      <button class="button--standard dropdown__button dropdown__button--mini button--add-calendar--mini"><span class="u-visually-hidden">Download calendar</span></button>
+  <div id="calendar-subscribe" class="export-widget">
+    <div class="dropdown js-button-icon-dropdown">
+      <button class="button button--standard dropdown__button button--subscribe" style="width: auto">Subscribe</button>
+      <ul class="dropdown__panel dropdown__panel--right" aria-hidden="true">
+        <li class="dropdown__item"><a class="dropdown__value" href="">Apple calendar</a></li>
+        <li class="dropdown__item"><a class="dropdown__value" href="">Google calendar</a></li>
+        <li class="dropdown__item"><a class="dropdown__value" href="">Microsoft Outlook calendar</a></li>
+      </ul>
     </div>
   </div>
+  <button class="button--standard button--subscribe">Button</button>
+
+  <div style="margin-top: 2rem">Download button: to initiate a download with a choice of formats</div>
+  <div id="calendar-subscribe" class="export-widget">
+    <div class="dropdown js-button-icon-dropdown">
+      <button class="button button--standard dropdown__button button--download--dropdown">Download</button>
+      <ul class="dropdown__panel dropdown__panel--right" aria-hidden="true">
+        <li class="dropdown__item"><a class="dropdown__value" href="">.ics</a></li>
+        <li class="dropdown__item"><a class="dropdown__value" href="">.csv</a></li>
+      </ul>
+    </div>
+  </div>
+  <button class="button--standard button--download">Button</button>
+
+  <div style="margin-top: 2rem">Add to calendar button</div>
+  <div id="calendar-subscribe" class="export-widget">
+    <div class="dropdown js-button-icon-dropdown">
+      <button class="button--standard dropdown__button dropdown__button--mini button--add-calendar--mini"><span class="u-visually-hidden">Download calendar</span></button>
+      <ul class="dropdown__panel" aria-hidden="true">
+        <li class="dropdown__item"><a class="dropdown__value" href="">Apple Calendar</a></li>
+        <li class="dropdown__item"><a class="dropdown__value" href="" target="_blank">Google Calendar</a></li>
+        <li class="dropdown__item"><a class="dropdown__value" href="">Outlook Calendar</a></li>
+      </ul>
+    </div>
+  </div>
+  <button class="button--standard button--add-calendar" style="margin-right: 2rem">Button</button>
 
   <div style="margin-top: 2rem">Two candidates button: toggle two-candidate view on map comparison</div>
   <button class="button--standard button--two-candidates" style="margin-right: 2rem">Button</button>

--- a/components/02-components/buttons/03-sizes/sizes.html
+++ b/components/02-components/buttons/03-sizes/sizes.html
@@ -1,4 +1,4 @@
-<div class="slab slab--neutral" style="padding: 1rem 2rem">
+<div class="slab" style="padding: 1rem 2rem">
   <div style="padding-bottom: 10px;">
     Small: <button class="button--standard button--sm">Button</button>
   </div>

--- a/components/02-components/filters/04-toggle-button/01-horizontal/horizontal.html
+++ b/components/02-components/filters/04-toggle-button/01-horizontal/horizontal.html
@@ -42,3 +42,16 @@
     </fieldset>
   </div>
 </div>
+
+<div class="slab slab--inline u-padding--left u-padding--right">
+  <div class="fc-button-group toggles--buttons">
+    <button type="button" class="fc-monthTime-button fc-button fc-state-default fc-corner-left button button--list button--alt fc-state-active">List</button>
+    <button type="button" class="fc-month-button fc-button fc-state-default fc-corner-right button button--grid button--alt">Grid</button>
+  </div>
+  <div class="fc-right">
+    <div class="fc-button-group toggles--buttons">
+      <button type="button" class="fc-monthTime-button fc-button fc-state-default fc-corner-left button button--list button--alt fc-state-active"><span class="u-visually-hidden">List</button>
+      <button type="button" class="fc-month-button fc-button fc-state-default fc-corner-right button button--grid button--alt"><span class="u-visually-hidden">Grid</button>
+    </div>
+  </div>
+</div>

--- a/fractal.js
+++ b/fractal.js
@@ -57,6 +57,7 @@ fractal.components.set('statuses', {
 // Theme
 const mandelbrot = require('@frctl/mandelbrot');
 const fecTheme = mandelbrot({
+    "favicon": "/img/favicon/favicon.ico",
     "skin": "navy",
     "nav": ["docs", "components"],
     "panels": ["notes", "html", "view", "context", "info"]

--- a/static/js/init.js
+++ b/static/js/init.js
@@ -24,6 +24,10 @@ $('.js-dropdown').each(function() {
   new dropdown.Dropdown(this);
 });
 
+$('.js-button-icon-dropdown').each(function() {
+  new dropdown.Dropdown(this, {checkboxes: false});
+});
+
 if ($('.js-keyword-modal').length > 0) {
   new KeywordModal();
 }


### PR DESCRIPTION
## Summary
- Updates the button component based on criteria set in #57 
  - Basic: Remove active state. The active state will be shown through the toggle component
  - Basic: Add more spacing between buttons so that they don't look so much like toggles
  - Icons: Show each button in just one color—color changes can be determined by the basic tab, and this will cut down clutter
  - Icons: Add dropdown buttons. These examples were missing from the components
  - Sizes: Remove the colored background slab to be consistent
- Adds additional toggle button examples discovered during research

![screen shot 2018-02-26 at 9 51 06 am](https://user-images.githubusercontent.com/11636908/36677075-482403a6-1adb-11e8-98ec-79fddc501b91.png)

![screen shot 2018-02-26 at 9 50 52 am](https://user-images.githubusercontent.com/11636908/36677078-4958c9c8-1adb-11e8-938c-ec176b00f2d3.png)

![screen shot 2018-02-26 at 9 50 36 am](https://user-images.githubusercontent.com/11636908/36677085-4c1e351c-1adb-11e8-9adb-e7f745a93042.png)

## Notes for review
- If #54 is merged before this PR, redirect this toward the master branch and any merge conflicts will need to be resolved.
- The "dropdown" functionality does not work in the examples I included of dropdown buttons with icons, and I'm not quite sure why. I'd like to merge without the functionality, since it's still useful in this state, and file a separate issue for making them work as examples.
- Resolves #57 