### PR TITLE
Update moment version per Gemnasium alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "aria-accordion": "^0.1.1",
     "jquery": "^3.1.1",
     "jquery.inputmask": "3.3.4",
-    "moment": "2.17.1",
+    "moment": "2.19.3",
     "perfect-scrollbar": "0.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Moment version from 2.17 to 2.19.3 to match CMS
Gemnasium alert: https://gemnasium.com/github.com/fecgov/fec-pattern-library/alerts#alert-7249688