### PR TITLE
Adds typography styles and restyles the typography on documentation pages

### DIFF
--- a/components/01-basics/_colors.html
+++ b/components/01-basics/_colors.html
@@ -52,7 +52,7 @@
     </div>
   </div>
 
-  <div class="slab" style="padding: 1rem 0">
+  <div class="slab t-sans" style="padding: 1rem 0">
     <div class="usa-width-one-fourth">
       <span class="t-bold">Crimson pairs with orange</span><br>
       The colors between are used to demonstrate interaction state changes
@@ -95,7 +95,7 @@
     </div>
   </div>
 
-  <div class="slab" style="padding: 1rem 0">
+  <div class="slab t-sans" style="padding: 1rem 0">
     <div class="usa-width-one-fourth">
       <span class="t-bold">White and gray pair with a dark base</span><br>
       The grays between are used to demonstrate interaction state changes
@@ -137,7 +137,7 @@
     </div>
   </div>
 
-  <div class="slab" style="padding: 1rem 0">
+  <div class="slab t-sans" style="padding: 1rem 0">
     <div class="usa-width-one-fourth">
       &nbsp;
     </div>

--- a/components/01-basics/_colors.html
+++ b/components/01-basics/_colors.html
@@ -1,18 +1,16 @@
-<div class="slab t-sans" style="padding: 4rem">
-
+<div class="slab slab--neutral" style="padding: 4rem">
   <h1 class="u-padding--bottom">Colors</h1>
+  <p class="t-lead">The specific combinations of color that help create brand consistency.</p>
+</div>
 
+<div class="container" style="padding: 2rem">
   <h2>Color palette</h2>
-
   <p>The FEC needed a defined color palette that was distinctly American, but avoided the partisan politcal connotations that are also associated with reds and blues. To accomplish this, the palette is used scientifically. To use both colors equally, the information architecture of the site is color coded: each major branch of the site is designed with deep blue accents, or deep red accents.</p>
-
   <p>The deep blues and reds are matched with bright complements to create a modern sense of gravitas. These pairs are also used scientifically, and blend only for illustrations of infographics.</p>
-
   <p>Grey and white pair in equal amounts with the red and blue to make versatile neutral space and features. They are the core design colors of the system, accentuated by the blue and red palettes.</p>
-
   <br>
 
-  <div class="slab" style="padding: 1rem 0">
+  <div class="slab t-sans" style="padding: 1rem 0">
     <div class="usa-width-one-fourth">
       <span class="t-bold">Federal blue pairs with aqua</span><br>
       The colors between are used to demonstrate interaction state changes

--- a/components/01-basics/_grid.html
+++ b/components/01-basics/_grid.html
@@ -1,64 +1,63 @@
-<div class="slab t-sans" style="padding: 2rem">
-
+<div class="slab slab--neutral" style="padding: 4rem">
   <h1 class="u-padding--bottom">Grid</h1>
-
-  Our design uses an underlying 12 column grid.
+  <p class="t-lead">This 12-column, responsive grid provides structure for website content.</p>
 </div>
 
-<div class="slab t-sans" style="padding: 0 2rem">
-  <div class="usa-width-one-twelfth" style="background-color: #d6d7d9; text-align: center">
-    1/12
-  </div>
-  <div class="usa-width-one-twelfth" style="background-color: #d6d7d9">
-    &nbsp;
-  </div>
-  <div class="usa-width-one-twelfth" style="background-color: #d6d7d9">
-    &nbsp;
-  </div>
-  <div class="usa-width-one-twelfth" style="background-color: #d6d7d9">
-    &nbsp;
-  </div>
-  <div class="usa-width-one-twelfth" style="background-color: #d6d7d9">
-    &nbsp;
-  </div>
-  <div class="usa-width-one-twelfth" style="background-color: #d6d7d9">
-    &nbsp;
-  </div>
-  <div class="usa-width-one-twelfth" style="background-color: #d6d7d9">
-    &nbsp;
-  </div>
-  <div class="usa-width-one-twelfth" style="background-color: #d6d7d9">
-    &nbsp;
-  </div>
-  <div class="usa-width-one-twelfth" style="background-color: #d6d7d9">
-    &nbsp;
-  </div>
-  <div class="usa-width-one-twelfth" style="background-color: #d6d7d9">
-    &nbsp;
-  </div>
-  <div class="usa-width-one-twelfth" style="background-color: #d6d7d9">
-    &nbsp;
-  </div>
-  <div class="usa-width-one-twelfth" style="background-color: #d6d7d9">
-    &nbsp;
+<div class="container" style="padding: 2rem">
+  <p>
+    The design uses an underlying 12 column grid, yet we use only a few combinations of column layouts. This keeps the total possible number of patterns to a minimum. Primarily, we use the full-width, 1/2-, 1/3-, and 1/4 width elements in combination with each other to create our layouts.
+  </p>
+  <div class="slab t-sans" style="padding: 0 2rem">
+    <div class="usa-width-one-twelfth" style="background-color: #d6d7d9; text-align: center">
+      1/12
+    </div>
+    <div class="usa-width-one-twelfth" style="background-color: #d6d7d9">
+      &nbsp;
+    </div>
+    <div class="usa-width-one-twelfth" style="background-color: #d6d7d9">
+      &nbsp;
+    </div>
+    <div class="usa-width-one-twelfth" style="background-color: #d6d7d9">
+      &nbsp;
+    </div>
+    <div class="usa-width-one-twelfth" style="background-color: #d6d7d9">
+      &nbsp;
+    </div>
+    <div class="usa-width-one-twelfth" style="background-color: #d6d7d9">
+      &nbsp;
+    </div>
+    <div class="usa-width-one-twelfth" style="background-color: #d6d7d9">
+      &nbsp;
+    </div>
+    <div class="usa-width-one-twelfth" style="background-color: #d6d7d9">
+      &nbsp;
+    </div>
+    <div class="usa-width-one-twelfth" style="background-color: #d6d7d9">
+      &nbsp;
+    </div>
+    <div class="usa-width-one-twelfth" style="background-color: #d6d7d9">
+      &nbsp;
+    </div>
+    <div class="usa-width-one-twelfth" style="background-color: #d6d7d9">
+      &nbsp;
+    </div>
+    <div class="usa-width-one-twelfth" style="background-color: #d6d7d9">
+      &nbsp;
+    </div>
   </div>
 </div>
 
-<div class="slab t-sans" style="padding: 4rem 2rem 2rem 2rem">
-  Yet we use only a few combinations of column layouts in order to keep the total possible number of patterns to a minimum. Primarily, we use the full-width, 1/2-, 1/3-, and 1/4 width elements in combination with each other to create our layouts.
-</div>
-
-<div class="main__content--full" style="background-color: #d6d7d9; margin-bottom: 2rem; padding: 4rem 2rem">
+<div class="main__content--full t-sans" style="background-color: #d6d7d9; margin-bottom: 2rem; padding: 4rem 2rem">
   100%
 </div>
 
-<div class="container" style="background-color: #d6d7d9; margin-bottom: 2rem; padding: 2rem">
+<div class="container t-sans" style="background-color: #d6d7d9; margin-bottom: 2rem; padding: 2rem">
   <div class="u-padding--top u-padding--bottom">
     1
   </div>
 </div>
 
-<div class="container">
+<div class="container t-sans">
   <div class="grid grid--2-wide">
     <div class="grid__item" style="background-color: #d6d7d9; padding: 4rem 1rem">
       1/2
@@ -69,7 +68,7 @@
   </div>
 </div>
 
-<div class="container">
+<div class="container t-sans">
   <div class="grid grid--3-wide">
     <div class="grid__item" style="background-color: #d6d7d9; padding: 4rem 1rem">
       1/3
@@ -83,7 +82,7 @@
   </div>
 </div>
 
-<div class="container">
+<div class="container t-sans">
   <div class="grid grid--4-wide">
     <div class="grid__item" style="background-color: #d6d7d9; padding: 4rem 1rem">
       1/4
@@ -100,12 +99,10 @@
   </div>
 </div>
 
-<div class="slab t-sans" style="padding: 2rem">
+<div class="slab t-sans t-sans" style="padding: 2rem">
   <h2>Most common grid layouts</h2>
-  <br>
-  <h3>Content with side element before</h3>
-
   <div class="container">
+    <h3>Content with side element before</h3>
     <div class="usa-width-one-fourth" style="background-color: #d6d7d9; padding: 4rem 1rem">
       1/4
     </div>
@@ -117,9 +114,8 @@
   <br>
   <br>
 
-  <h3>Content with side element after</h3>
-
   <div class="container">
+    <h3>Content with side element after</h3>
     <div class="usa-width-two-thirds" style="background-color: #d6d7d9; padding: 4rem 1rem">
       2/3
     </div>
@@ -131,9 +127,8 @@
   <br>
   <br>
 
-  <h3>Content with side element before and after</h3>
-
   <div class="container">
+    <h3>Content with side element before and after</h3>
     <div class="usa-width-one-fourth" style="background-color: #d6d7d9; padding: 4rem 1rem">
       1/4
     </div>

--- a/components/01-basics/_icons.html
+++ b/components/01-basics/_icons.html
@@ -3,9 +3,15 @@
   and run `npm run build-icons-component`
 -->
 
-<div class="slab" style="padding: 2rem">
+<div class="slab slab--neutral" style="padding: 4rem">
   <h1 class="u-padding--bottom">Icons</h1>
-  <div class="grid grid--4-wide">
+  <p class="t-lead">
+    Small graphics that visually reinforce an interface action, file type, status, or category. They are almost always used in context with descriptive text and function to reinforce the message of that text.
+  </p>
+</div>
+
+<div class="container t-sans" style="padding: 4rem">
+  <div class="grid grid--6-wide">
 
     <div class="grid__item">
       <i class="i i-all-files"></i>

--- a/components/01-basics/_typography.html
+++ b/components/01-basics/_typography.html
@@ -333,7 +333,21 @@
     <div class="usa-width-three-fourths t-serif">
         <p class="t-note t-sans">Examples: 102.2; electioneering</p>
         <p class="t-note">These totals are drawn from quarterly, monthly and semi-annual reports. 24- and 48-Hour Reports of independent expenditures aren't included.</p>
-      </blockquote>
+    </div>
+  </div>
+
+  <div class="slab">
+    <div class="usa-width-one-fourth">
+      <span class="t-bold">Excerpt copy</span><br>
+      Karla regular, 1.6rem (16pt)<br>
+      kerning: -.3px<br>
+      <em>Used in post excerpts</em>
+    </div>
+
+    <div class="usa-width-three-fourths t-serif">
+        <p class="t-sans js-post-content">
+          WASHINGTON – The Federal Election Commission has introduced its new website, offering improved navigation and an array of intuitive new tools to mine the agency’s rich campaign finance data set ...
+        </p>
     </div>
   </div>
 

--- a/components/01-basics/_typography.html
+++ b/components/01-basics/_typography.html
@@ -1,21 +1,24 @@
-<div class="slab t-sans" style="padding: 4rem">
-
+<div class="slab slab--neutral" style="padding: 4rem">
   <h1 class="u-padding--bottom">Typography</h1>
+  <p class="t-lead">Two primary font families create the system: Gandhi serif and Karla.</p>
+</div>
 
-  <p>We use two fonts in the new system: Gandhi serif and Karla.</p>
-
+<div class="container" style="padding: 2rem">
   <h2>Gandhi serif</h2>
+  <p>
+    Gandhi serif is the primary font across the site, used for paragraph copy and main headlines. We sought out a serif that had medium contrast for best web and print readability, a strong bold weight that could be used for clear headline hierarchy, and felt traditional and dependable, without much embellishment to distract the eye. The font also needed to be free, and without licensing restrictions on distribution or use so that it would be aligned in values with an open source project.
+  </p>
 
   <div class="slab">
     <div class="usa-width-one-third t-serif">
       <h3 class="t-normal">Gandhi serif regular</h3>
       <p>The quick candidates and their authorized committees jumped over the lazy brown fox-dog.<br>
-      $ § ? 0 1 2 3 4 5 6 7 8 9<br>
+      $ § ? 0 1 2 3 4 5 6 7 8 9</p>
     </div>
     <div class="usa-width-one-third t-serif t-italic">
       <h3 class="t-normal">Gandhi serif regular italic</h3>
       <p>The quick corporations and their labor organizations jumped over the lazy brown fox-dog.<br>
-      $ § ? 0 1 2 3 4 5 6 7 8 9<br>
+      $ § ? 0 1 2 3 4 5 6 7 8 9</p>
     </div>
   </div>
 
@@ -23,67 +26,57 @@
     <div class="usa-width-one-third t-serif t-bold">
       <h3>Gandhi serif bold</h3>
       <p>The quick political action committees jumped over the lazy brown fox-dog.<br>
-      $ § ? 0 1 2 3 4 5 6 7 8 9<br>
+      $ § ? 0 1 2 3 4 5 6 7 8 9</p>
     </div>
     <div class="usa-width-one-third t-serif t-italic t-bold">
       <h3>Gandhi serif bold italic</h3>
       <p>The quick political party committees jumped over the lazy brown fox-dog.<br>
-      $ § ? 0 1 2 3 4 5 6 7 8 9<br>
+      $ § ? 0 1 2 3 4 5 6 7 8 9</p>
     </div>
   </div>
 
   <p>
-    Gandhi serif is our primary font across the site, used for paragraph copy and main headlines. We sought out a serif that had medium contrast for best web and print readability, a strong bold weight that could be used for clear headline hierarchy, and felt traditional and dependable, without much embellishment to distract the eye. The font also needed to be free, and without licensing restrictions on distribution or use so that it would be aligned in values with an open source project.
+    In our initial research. we heard from the FEC IT and multimedia teams that <span class="t-bold">they needed a design that held up in both print and web environments</span> so it would be easy to put print publications online, and easy to print publications directly from the web.
+    Gandhi was designed by a publishing company especially for this scenario—it ranks high in readability both on web and when printed. Many FEC website users often print pages of the FEC website for reference, and this font was specifically designed to perform well in that scenario.
   </p>
 
-  <p>In our initial research. we heard from the FEC IT and multimedia teams that <span class="t-bold">they needed a design that held up in both print and web environments</span> so it would be easy to put print publications online, and easy to print publications directly from the web.
-  <ul class="list--bulleted">
-    <li><p>Gandhi was designed by a publishing company especially for this scenario—it ranks high in readability both on web and when printed. Many FEC website users often print pages of the FEC website for reference, and this font was specifically designed to perform well in that scenario.</p></li>
-  </ul>
-  </p>
   <p>
-  <span class="t-bold">We also needed to prepare to support multiple languages</span>
-  <ul class="list--bulleted">
-    <li>Gandhi specifically has excellent Spanish language character support</li>
-  </ul>
+    <span class="t-bold">We also needed to prepare to support multiple languages in the future.</span><br>Gandhi specifically has excellent Spanish language character support
   </p>
 
   <div class="slab">
-    <h2 class="u-no-margin-bottom">Karla</h2>
+    <h2>Karla</h2>
+    <p>
+      Karla is our secondary font used across the site. Used in data tables, visualizations, and footnote-like text, to keep a clear visual distinction from paragraph and headline copy. To balance the traditional feel of Gandhi, we sought out a modern sans serif with a clean, airy feeling, and wider spacing built in. We were especially critical in choosing a font that had precise, unembellished numerals, since we knew it would be used for financial data. There is also high contrast between the regular and bold weights, which allows us to combine them in table designs, and retain clear hierarchy with just one font. Karla is also an open source font, and free to use.
+    </p>
   </div>
 
-  <div class="slab">
+  <div class="slab t-sans">
     <div class="usa-width-one-third">
       <h3 class="t-sans t-normal">Karla regular</h3>
       <p>The quick candidates and their authorized committees jumped over the lazy brown fox-dog.<br>
-      $ § ? 0 1 2 3 4 5 6 7 8 9<br>
+      $ § ? 0 1 2 3 4 5 6 7 8 9</p>
     </div>
     <div class="usa-width-one-third t-italic">
       <h3 class="t-sans t-normal">Karla regular italic</h3>
       <p>The quick candidates and their authorized committees jumped over the lazy brown fox-dog.<br>
-      $ § ? 0 1 2 3 4 5 6 7 8 9<br>
+      $ § ? 0 1 2 3 4 5 6 7 8 9</p>
     </div>
   </div>
 
-  <div class="slab u-no-padding">
+  <div class="slab t-sans u-no-padding">
     <div class="usa-width-one-third t-bold">
       <h3 class="t-sans">Karla bold</h3>
       <p>The quick candidates and their authorized committees jumped over the lazy brown fox-dog.<br>
-      $ § ? 0 1 2 3 4 5 6 7 8 9<br>
+      $ § ? 0 1 2 3 4 5 6 7 8 9</p>
     </div>
   </div>
 
-  <p>Karla is our secondary font used across the site. We use in data tables, visualizations, and footnote-like text, to keep a clear visual distinction from paragraph and headline copy. To balance the traditional feel of Gandhi, we sought out a modern sans serif with a clean, airy feeling, and wider spacing built in. We were especially critical in choosing a font that had precise, unembellished numerals, since we knew it would be used for financial data. There is also high contrast between the regular and bold weights, which allows us to combine them in table designs, and retain clear hierarchy with just one font. Karla is also an open source font, and free to use.</p>
-
-  <h2>Other background on typography</h2>
-  <p class="t-bold">In early interviews, we heard from FEC staff that they wanted clear design guidelines that helped make the new styles easy to achieve, and hard to get wrong.</p>
-  <ul class="list--bulleted">
-    <li><p>One way we wanted to support this through typography was to keep the number of fonts in the system low, so that it was easier to know which font to use when. We also specifically chose fonts that had few (but just enough) differences in weights to choose from. Both Karla and Gandhi only have two weights: Regular and Bold, each with matching italics.</p></li>
-  </ul>
-
-  <br>
-  <br>
-
+  <h2 class="u-margin--top">Other background on typography</h2>
+  <p>In early interviews, we heard from FEC staff that they wanted clear design guidelines that helped make the new styles easy to achieve, and hard to get wrong.</p>
+  <p>One way we wanted to support this through typography was to keep the number of fonts in the system low, so that it was easier to know which font to use when. We also specifically chose fonts that had few (but just enough) differences in weights to choose from. Both Karla and Gandhi only have two weights: Regular and Bold, each with matching italics.</p>
+  <br> 
+<div class="option t-sans">
   <h2>Type styles</h2>
 
   <div class="slab">
@@ -313,5 +306,5 @@
       </ul>
     </div>
   </div>
-
+<div>
 </div>

--- a/components/01-basics/_typography.html
+++ b/components/01-basics/_typography.html
@@ -309,6 +309,36 @@
 
   <div class="slab">
     <div class="usa-width-one-fourth">
+      <span class="t-bold">Labels</span><br>
+      Karla bold, 1.4rem (14pt)<br>
+      kerning: -.3px<br>
+      <em>Used for filter or form field labels and document type labels</em>
+    </div>
+
+    <div class="usa-width-three-fourths t-serif">
+      <div class="grid grid--2-wide">
+        <div class="grid__item">
+          <div class="filter">
+          <label class="label" for="publication-type">Publication type</label>
+          <select id="publication-type" name="update_type">
+            <option value="">All</option>
+            <option value="fec-record">FEC Record</option>
+            <option value="press-release">Press releases</option>
+            <option value="tips-for-treasurers">Tips for Treasurers</option>
+            <option value="weekly-digest">Weekly Digests</option>
+          </select>
+          </div>
+        </div>
+        <div class="grid__item">
+           <span class="label">PDF Guide</span>
+           <a class="t-sans" href="#">Congressional candidates and committees campaign guide</a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="slab">
+    <div class="usa-width-one-fourth">
       <span class="t-bold">Blockquotes</span><br>
       <em>Italicized body copy visually separated from a paragraph block</em>
     </div>

--- a/components/01-basics/_typography.html
+++ b/components/01-basics/_typography.html
@@ -321,5 +321,21 @@
     </div>
   </div>
 
+  <div class="slab">
+    <div class="usa-width-one-fourth">
+      <span class="t-bold">Note/description</span><br>
+      No pre-defined font family<br>
+      Regular italic, 1.4rem (14pt)<br>
+      line height: 1.8<br>
+      <em>Used as example text or as a note about content</em>
+    </div>
+
+    <div class="usa-width-three-fourths t-serif">
+        <p class="t-note t-sans">Examples: 102.2; electioneering</p>
+        <p class="t-note">These totals are drawn from quarterly, monthly and semi-annual reports. 24- and 48-Hour Reports of independent expenditures aren't included.</p>
+      </blockquote>
+    </div>
+  </div>
+
 <div>
 </div>

--- a/components/01-basics/_typography.html
+++ b/components/01-basics/_typography.html
@@ -75,7 +75,7 @@
   <h2 class="u-margin--top">Other background on typography</h2>
   <p>In early interviews, we heard from FEC staff that they wanted clear design guidelines that helped make the new styles easy to achieve, and hard to get wrong.</p>
   <p>One way we wanted to support this through typography was to keep the number of fonts in the system low, so that it was easier to know which font to use when. We also specifically chose fonts that had few (but just enough) differences in weights to choose from. Both Karla and Gandhi only have two weights: Regular and Bold, each with matching italics.</p>
-  <br> 
+  <br>
 <div class="option t-sans">
   <h2>Type styles</h2>
 
@@ -306,5 +306,20 @@
       </ul>
     </div>
   </div>
+
+  <div class="slab">
+    <div class="usa-width-one-fourth">
+      <span class="t-bold">Blockquotes</span><br>
+      <em>Italicized body copy visually separated from a paragraph block</em>
+    </div>
+
+    <div class="usa-width-three-fourths t-serif">
+      <blockquote>
+        <p>“There was a drop down, but no place to write in text. We would have expenses that didn’t quite match what was in the dropdown. This led to questions like “we are trying to do this as accurately as possible, but if this category is not right, is the blame on us…?” I wanted to make sure I crossed Ts and dotted Is… oftentimes it didn’t seem clear how to list certain expenses from that dropdown menu.”</p>
+        <p>—Filer</p>
+      </blockquote>
+    </div>
+  </div>
+
 <div>
 </div>


### PR DESCRIPTION
## Summary

Adds the following typography styles to the [Typography](https://fec-pattern-library.app.cloud.gov/docs/typography.html) documentation page from #38 :
- Labels
- Blockqupotes
- Note/description
- Excerpt copy

![screen shot 2018-03-20 at 10 14 54 pm](https://user-images.githubusercontent.com/11636908/37692134-2ea398c4-2c8d-11e8-8a93-274a752beb70.png)


Creates a consistent layout for documentation page formatting, based on styles used in #89. Uses a neutral background colored slab at the top, with a lead introduction. 

![screen shot 2018-03-20 at 10 17 02 pm](https://user-images.githubusercontent.com/11636908/37692137-34aac6e8-2c8d-11e8-866e-5ca22c53cbb8.png)
![screen shot 2018-03-20 at 10 16 12 pm](https://user-images.githubusercontent.com/11636908/37692141-388cb05a-2c8d-11e8-839c-2ab07ef912f1.png)
![screen shot 2018-03-20 at 10 16 35 pm](https://user-images.githubusercontent.com/11636908/37692142-38980266-2c8d-11e8-91b5-353f03b7db5b.png)
![screen shot 2018-03-20 at 10 16 48 pm](https://user-images.githubusercontent.com/11636908/37692143-38a286f0-2c8d-11e8-9a4b-5efc269f9cc8.png)

### Related issues
Resolves #38 