### PR TITLE
Style USWDS resources better and add GitHub history to components

### DIFF
--- a/components/02-components/accordions/README.md
+++ b/components/02-components/accordions/README.md
@@ -8,9 +8,6 @@ Accordions are collapsible panels that provide users with the ability to expand 
 - If visitors need to see most or all of the information on a page. Use well-formatted text instead.
 - If there is not enough content to warrant condensing. Accordions increase cognitive load and interaction cost, as users have to make decisions about what headers to click on.
 
-## Guidance
-- Allow users to click anywhere in the header area to expand or collapse the content; a larger target is easier to manipulate.
-- Make sure interactive elements within the collapsible region are far enough from the headers that users don’t accidentally trigger a collapse. (The exact distance depends on the device.)
-
-### Resources
-Learn more about accessibility and best practices for accordions from the [U.S. Web Design System](https://designsystem.digital.gov/components/accordions/).
+### Guidance from the [U.S. Web Design System](https://designsystem.digital.gov/components/accordions/)
+> - Allow users to click anywhere in the header area to expand or collapse the content; a larger target is easier to manipulate.
+> - Make sure interactive elements within the collapsible region are far enough from the headers that users don’t accidentally trigger a collapse. (The exact distance depends on the device.)

--- a/components/02-components/accordions/README.md
+++ b/components/02-components/accordions/README.md
@@ -11,3 +11,6 @@ Accordions are collapsible panels that provide users with the ability to expand 
 ### Guidance from the [U.S. Web Design System](https://designsystem.digital.gov/components/accordions/)
 > - Allow users to click anywhere in the header area to expand or collapse the content; a larger target is easier to manipulate.
 > - Make sure interactive elements within the collapsible region are far enough from the headers that users don’t accidentally trigger a collapse. (The exact distance depends on the device.)
+
+### GitHub issues
+ - [#315: Improve usability and visual design of accordion elements](https://github.com/18f/fec-style/issues/315)

--- a/components/02-components/breadcrumbs/README.md
+++ b/components/02-components/breadcrumbs/README.md
@@ -4,7 +4,7 @@ The breadcrumbs component is used for navigation and to reinforce users' awarene
 The background container color for the breadcrumbs bar should match the color assigned to the information architecture of that section of the website. You can find this color by matching it to the color of the hero slab on the section's main landing page.
 
 ## When to use
-- On any page deeper in the site architecture than the main section landing pages 
+- On any page deeper in the site architecture than the main section landing pages
 
 ## When to consider something else
  - If the page is a landing page for one of the top-level menu items, breadcrumbs aren't needed and can be omitted. These pages include:
@@ -13,3 +13,6 @@ The background container color for the breadcrumbs bar should match the color as
   - `/legal-resources`
   - `/about`
   - `/press`
+
+  ### GitHub issues
+   - [#1595: Style breadcrumbs](https://github.com/fecgov/openFEC/issues/1595)

--- a/components/02-components/buttons/01-basic/README.md
+++ b/components/02-components/buttons/01-basic/README.md
@@ -11,15 +11,12 @@ Buttons follow the **color pairing** rules used across the site. There are three
 - If you want to lead users between pages of a website. Use links instead.
 - Less popular or less important actions may be visually styled as links.
 
-## Guidance
-- Generally, use primary buttons for actions that go to the next step and use secondary buttons for actions that happen on the current page.
-- Style the button most users should click in a way that distinguishes from other buttons on the page. Try using the “large button” or the most visually distinct fill color.
-- Make sure buttons should look clickable—use color variations to distinguish static, hover and active states.
-- Avoid using too many buttons on a page.
-- Use sentence case for button labels.
-- Button labels should be as short as possible with “trigger words” that your users will recognize to clearly explain what will happen when the button is clicked (for example, “download,” “view” or “sign up”).
-- Make the first word of the button’s label a verb. For example, instead of “Complaint Filing” label the button “File a complaint.”
-- At times, consider adding an icon to signal specific actions (“download”, “open in a new window”, etc).
-
-### Resources
-Learn more about accessibility and best practices for buttons from the [U.S. Web Design System](https://designsystem.digital.gov/components/buttons/).
+### Guidance from the [U.S. Web Design System](https://designsystem.digital.gov/components/buttons/)
+> - Generally, use primary buttons for actions that go to the next step and use secondary buttons for actions that happen on the current page.
+> - Style the button most users should click in a way that distinguishes from other buttons on the page. Try using the “large button” or the most visually distinct fill color.
+> - Make sure buttons should look clickable—use color variations to distinguish static, hover and active states.
+> - Avoid using too many buttons on a page.
+> - Use sentence case for button labels.
+> - Button labels should be as short as possible with “trigger words” that your users will recognize to clearly explain what will happen when the button is clicked (for example, “download,” “view” or “sign up”).
+> - Make the first word of the button’s label a verb. For example, instead of “Complaint Filing” label the button “File a complaint.”
+> - At times, consider adding an icon to signal specific actions (“download”, “open in a new window”, etc).

--- a/components/02-components/buttons/01-basic/README.md
+++ b/components/02-components/buttons/01-basic/README.md
@@ -20,3 +20,7 @@ Buttons follow the **color pairing** rules used across the site. There are three
 > - Button labels should be as short as possible with “trigger words” that your users will recognize to clearly explain what will happen when the button is clicked (for example, “download,” “view” or “sign up”).
 > - Make the first word of the button’s label a verb. For example, instead of “Complaint Filing” label the button “File a complaint.”
 > - At times, consider adding an icon to signal specific actions (“download”, “open in a new window”, etc).
+
+### GitHub issues
+ - [#288: Revise base button design](https://github.com/18F/fec-style/issues/288)
+ - [#297: Implement new button styles](https://github.com/18F/fec-style/issues/297)

--- a/components/02-components/filter-tags/README.md
+++ b/components/02-components/filter-tags/README.md
@@ -7,3 +7,4 @@ Tags aren’t removable when they apply strict limits to the data being viewed, 
 ### GitHub issues
  - [#1330: Interaction construction of and/or signifier in tag area of data tables](https://github.com/18F/openFEC-web-app/issues/1330)
  - [#1329: Visual design of co-located tag and filter system](https://github.com/18F/openFEC-web-app/issues/1329)
+ - [#1872: Design specific tag UI for date ranges and financial ranges](https://github.com/fecgov/openFEC/issues/1872#issuecomment-241447101)

--- a/components/02-components/filter-tags/README.md
+++ b/components/02-components/filter-tags/README.md
@@ -3,3 +3,7 @@ Filter tags help users track and confirm which filters have been applied when th
 Tags aren’t removable when they apply strict limits to the data being viewed, such as
 - one two-year period of time per search
 - a persistent toggle, like processed/raw data
+
+### GitHub issues
+ - [#1330: Interaction construction of and/or signifier in tag area of data tables](https://github.com/18F/openFEC-web-app/issues/1330)
+ - [#1329: Visual design of co-located tag and filter system](https://github.com/18F/openFEC-web-app/issues/1329)

--- a/components/02-components/filters/01-checkboxes/01-multiple/README.md
+++ b/components/02-components/filters/01-checkboxes/01-multiple/README.md
@@ -9,11 +9,8 @@ Checkboxes allow users to select one or more options from a visible list.
 - If there are too many options to display on a mobile screen.
 - If a user can only select one option from a list (use radio buttons instead).
 
-## Guidelines
-- Users should be able to tap on or click on either the text label or the checkbox to select or deselect an option.
-- List options vertically if possible; horizontal listings can make it difficult to tell which label pertains to which checkbox.
-- Avoid using negative language in labels as they can be counterintuitive. For example, “I want to receive a promotional email” instead of “I don’t want to receive promotional email.”
-- Make sure selections are adequately spaced for touch screens.
-
-### Resources
-Learn more about accessibility and best practices for checkboxes from the [U.S. Web Design System](https://designsystem.digital.gov/components/form-controls/#checkboxes).
+### Guidance from the [U.S. Web Design System](https://designsystem.digital.gov/components/form-controls/#checkboxes)
+> - Users should be able to tap on or click on either the text label or the checkbox to select or deselect an option.
+> - List options vertically if possible; horizontal listings can make it difficult to tell which label pertains to which checkbox.
+> - Avoid using negative language in labels as they can be counterintuitive. For example, “I want to receive a promotional email” instead of “I don’t want to receive promotional email.”
+> - Make sure selections are adequately spaced for touch screens.

--- a/components/02-components/filters/01-checkboxes/01-multiple/README.md
+++ b/components/02-components/filters/01-checkboxes/01-multiple/README.md
@@ -14,3 +14,6 @@ Checkboxes allow users to select one or more options from a visible list.
 > - List options vertically if possible; horizontal listings can make it difficult to tell which label pertains to which checkbox.
 > - Avoid using negative language in labels as they can be counterintuitive. For example, “I want to receive a promotional email” instead of “I don’t want to receive promotional email.”
 > - Make sure selections are adequately spaced for touch screens.
+
+### GitHub issues
+ - [#314: Improve usability and visual design of check box and radio button elements](https://github.com/18f/fec-style/issues/314)

--- a/components/02-components/filters/02-radio-buttons/README.md
+++ b/components/02-components/filters/02-radio-buttons/README.md
@@ -13,3 +13,6 @@ Radio buttons allow users to select exactly one option from a visible list.
 > - Users should be able to tap on or click on either the text “label” or the radio button to select or deselect an option.
 > - Options that are listed vertically are easier to read than those that are listed horizontally. Horizontal listings can make it difficult to tell which label pertains to which radio button.
 > - Use caution if you decide to set a default value. Setting a default value can discourage users from making conscious decisions, seem pushy, or alienate users who don’t fit into your assumptions. If you are unsure, leave nothing selected by default.
+
+### GitHub issues
+ - [#314: Improve usability and visual design of check box and radio button elements](https://github.com/18f/fec-style/issues/314)

--- a/components/02-components/filters/02-radio-buttons/README.md
+++ b/components/02-components/filters/02-radio-buttons/README.md
@@ -9,10 +9,7 @@ Radio buttons allow users to select exactly one option from a visible list.
 - Consider a dropdown if you don’t have enough space to list out all available options.
 - If users should be able to select zero of the options.
 
-## Guidance
-- Users should be able to tap on or click on either the text “label” or the radio button to select or deselect an option.
-- Options that are listed vertically are easier to read than those that are listed horizontally. Horizontal listings can make it difficult to tell which label pertains to which radio button.
-- Use caution if you decide to set a default value. Setting a default value can discourage users from making conscious decisions, seem pushy, or alienate users who don’t fit into your assumptions. If you are unsure, leave nothing selected by default.
-
-### Resources
-Learn more about accessibility and best practices for radio buttons from the [U.S. Web Design System](https://designsystem.digital.gov/components/form-controls/#radio-buttons.
+### Guidance from the [U.S. Web Design System](https://designsystem.digital.gov/components/form-controls/#radio-buttons)
+> - Users should be able to tap on or click on either the text “label” or the radio button to select or deselect an option.
+> - Options that are listed vertically are easier to read than those that are listed horizontally. Horizontal listings can make it difficult to tell which label pertains to which radio button.
+> - Use caution if you decide to set a default value. Setting a default value can discourage users from making conscious decisions, seem pushy, or alienate users who don’t fit into your assumptions. If you are unsure, leave nothing selected by default.

--- a/components/02-components/filters/03-dropdowns/01-single-select/README.md
+++ b/components/02-components/filters/03-dropdowns/01-single-select/README.md
@@ -9,8 +9,5 @@ Single select dropdowns allow users to select one option.
 - If the list of options is very short. Use radio buttons or checkboxes instead.
 - If the list of options is very long. Let users type the same information into a text input that suggests possible options instead (search with typeahead matching).
 
-## Guidance
-Test dropdowns thoroughly with members of your target audience. Several usability experts suggest they should be the “UI of last resort.” Many users find them confusing and difficult to use.
-
-### Resources
-Learn more about accessibility and best practices for dropdowns from the [U.S. Web Design System](https://designsystem.digital.gov/components/form-controls/#dropdown).
+### Guidance from the [U.S. Web Design System](https://designsystem.digital.gov/components/form-controls/#dropdown)
+> Test dropdowns thoroughly with members of your target audience. Several usability experts suggest they should be the “UI of last resort.” Many users find them confusing and difficult to use.

--- a/components/02-components/filters/03-dropdowns/01-single-select/README.md
+++ b/components/02-components/filters/03-dropdowns/01-single-select/README.md
@@ -11,3 +11,6 @@ Single select dropdowns allow users to select one option.
 
 ### Guidance from the [U.S. Web Design System](https://designsystem.digital.gov/components/form-controls/#dropdown)
 > Test dropdowns thoroughly with members of your target audience. Several usability experts suggest they should be the “UI of last resort.” Many users find them confusing and difficult to use.
+
+### GitHub issues
+ - [#297: Implement new button styles](https://github.com/18F/fec-style/issues/297)

--- a/components/02-components/filters/03-dropdowns/02-multi-select/README.md
+++ b/components/02-components/filters/03-dropdowns/02-multi-select/README.md
@@ -1,5 +1,5 @@
 ## When to use
 - When a user needs to select multiple options from a hidden list
 
-### Resources
-Learn more about accessibility and best practices for dropdowns from the [U.S. Web Design System](https://designsystem.digital.gov/components/form-controls/#dropdown).
+### Guidance from the [U.S. Web Design System](https://designsystem.digital.gov/components/form-controls/#dropdown)
+> Test dropdowns thoroughly with members of your target audience. Several usability experts suggest they should be the “UI of last resort.” Many users find them confusing and difficult to use.

--- a/components/02-components/filters/03-dropdowns/03-multi-select-with-suggestions/README.md
+++ b/components/02-components/filters/03-dropdowns/03-multi-select-with-suggestions/README.md
@@ -1,5 +1,5 @@
 ## When to use
 - When analytics or research can show that certain options are applied much more often than others, it can be helpful to surface those most common options outside of the hidden list.
 
-### Resources
-Learn more about accessibility and best practices for dropdowns from the [U.S. Web Design System](https://designsystem.digital.gov/components/form-controls/#dropdown).
+### Guidance from the [U.S. Web Design System](https://designsystem.digital.gov/components/form-controls/#dropdown)
+> Test dropdowns thoroughly with members of your target audience. Several usability experts suggest they should be the “UI of last resort.” Many users find them confusing and difficult to use.

--- a/components/02-components/filters/04-toggle-button/01-horizontal/README.md
+++ b/components/02-components/filters/04-toggle-button/01-horizontal/README.md
@@ -1,1 +1,4 @@
 A styled set of radio buttons that can have a single entry selected at any one time. Use a toggle button when the interaction indicates whether a setting is on or off for an entire view. Toggles should have as few options as possible.
+
+### GitHub issues
+ - [#297: Implement new button styles](https://github.com/18F/fec-style/issues/297)

--- a/components/02-components/filters/04-toggle-button/02-vertical/README.md
+++ b/components/02-components/filters/04-toggle-button/02-vertical/README.md
@@ -1,1 +1,4 @@
 When horizontal space is limited, such as in a filter panel or mobile view, toggle buttons can stack vertically.
+
+### GitHub issues
+ - [#297: Implement new button styles](https://github.com/18F/fec-style/issues/297)

--- a/components/02-components/filters/06-range/02-range-limited/README.md
+++ b/components/02-components/filters/06-range/02-range-limited/README.md
@@ -1,1 +1,5 @@
 Allows users to set a custom period within a pre-defined limit. Often used for narrowing a span of time within a two-year period. When used for dates, a calendar picker toggles below to help refine the time period.
+
+### GitHub issues
+ - [#1375: Update and unify date filter patterns](https://github.com/18F/openFEC-web-app/issues/1375)
+ - [#1872: Design specific tag UI for date ranges and financial ranges](https://github.com/fecgov/openFEC/issues/1872#issuecomment-241447101)

--- a/components/02-components/filters/07-search/01-type-ahead-only/README.md
+++ b/components/02-components/filters/07-search/01-type-ahead-only/README.md
@@ -1,2 +1,7 @@
 ## When to use
 - When the search field only accepts type-ahead matching to choose an option from a pre-defined set of data
+
+### GitHub issues
+ - [#231: Consolidate typeahead](https://github.com/18F/fec-style/pull/231)
+ - [#1594: Test typeahead filter in usability testing](https://github.com/fecgov/openFEC/issues/1594)
+ - [#349: Improved typeahead interaction](https://github.com/18F/fec-style/pull/349)

--- a/components/02-components/filters/07-search/02-type-ahead-and-free-text/README.md
+++ b/components/02-components/filters/07-search/02-type-ahead-and-free-text/README.md
@@ -3,3 +3,8 @@
 Use this type of filter when the search field must accept both:
 - type-ahead matching to choose an option from pre-defined set of data; AND
 - free text keywords
+
+### GitHub issues
+ - [#231: Consolidate typeahead](https://github.com/18F/fec-style/pull/231)
+ - [#1594: Test typeahead filter in usability testing](https://github.com/fecgov/openFEC/issues/1594)
+ - [#349: Improved typeahead interaction](https://github.com/18F/fec-style/pull/349)

--- a/components/02-components/filters/07-search/03-free-text-only/README.md
+++ b/components/02-components/filters/07-search/03-free-text-only/README.md
@@ -1,2 +1,5 @@
 ## When to use
 - When the search field can only accept free text keywords
+
+### GitHub issues
+ - [#1828: Unify text input filter patterns](https://github.com/fecgov/openFEC/issues/1828)

--- a/components/02-components/footer/README.md
+++ b/components/02-components/footer/README.md
@@ -1,1 +1,5 @@
- The footer should be positioned at the bottom of all FEC.gov pages and connected apps. It hosts a secondary, alternative set of information and resources about the site and agency. 
+ The footer should be positioned at the bottom of all FEC.gov pages and connected apps. It hosts a secondary, alternative set of information and resources about the site and agency.
+
+ ### GitHub issues
+  - [#484: Figure out all the required things we need to link to, and where they should/need to appear on the site](https://github.com/fecgov/fec-cms/issues/484)
+  - [#498: Visual design of footer navigation](https://github.com/18F/fec-style/issues/498)

--- a/components/02-components/header/README.md
+++ b/components/02-components/header/README.md
@@ -3,3 +3,6 @@
 
 ## When to consider something else
 - A prominent display scenario on the website home page. The home page uses a custom version of the standard header that displays a larger and uncropped version of the FEC seal.  
+
+### GitHub issues
+ - [#313: To maximize useful page real estate, consider designing a mini-header for interior pages](https://github.com/18F/fec-style/issues/313)

--- a/components/02-components/heroes/README.md
+++ b/components/02-components/heroes/README.md
@@ -6,3 +6,6 @@ Existing color associations:
 - Legal resources: `.primary`
 - About: `.secondary`
 - Press: `.secondary`
+
+### GitHub issues
+ - [#330: Reduce height of hero](https://github.com/18F/fec-style/issues/330)

--- a/components/02-components/loading-overlay/README.md
+++ b/components/02-components/loading-overlay/README.md
@@ -1,1 +1,4 @@
 The loading overlay indicates to users that the site is responding to their actions and actively processing an action. An overlay is placed over a table or list while results are filtered, sorted, or loaded.
+
+### GitHub issues
+ - [#24: Design loading state on tables](https://github.com/18F/fec-style/issues/24)

--- a/components/02-components/messages/01-message-sizes/README.md
+++ b/components/02-components/messages/01-message-sizes/README.md
@@ -24,3 +24,6 @@ _Ex: Export warnings on [data tables](https://www.fec.gov/data/receipts)_
 > - But don’t overdo it — too many notifications will either overwhelm or annoy the user and are likely to be ignored.
 > - Allow a user to dismiss a notification wherever appropriate.
 > - Don’t include notifications that aren’t related to the user’s current goal.
+
+### GitHub issues
+ - [#266: Unify error / info / message styles](https://github.com/18f/fec-style/issues/266)

--- a/components/02-components/messages/01-message-sizes/README.md
+++ b/components/02-components/messages/01-message-sizes/README.md
@@ -17,5 +17,10 @@ Messages keep users informed of important and sometimes time-sensitive changes.
 _Ex: Time-sensitive events being promoted on the [home page](https://www.fec.gov/)_</br>
 _Ex: Export warnings on [data tables](https://www.fec.gov/data/receipts)_
 
-### Resources
-Learn more about accessibility and best practices for alerts from the [U.S. Web Design System](https://designsystem.digital.gov/components/alerts/).
+### Guidance from the [U.S. Web Design System](https://designsystem.digital.gov/components/alerts/)
+> - When the user is required to do something in response to an alert, let them know what they need to do and make that task as easy as possible. Think about how much context to provide with your message. For example, a notification of a system change may require more contextual information than a validation message. Write the message in concise, human readable language; avoid jargon and computer code.
+> - Be polite in error messages — don’t place blame on the user.
+> - Users generally won’t read documentation but will read a message that helps them resolve an error; include some educational material in your error message.
+> - But don’t overdo it — too many notifications will either overwhelm or annoy the user and are likely to be ignored.
+> - Allow a user to dismiss a notification wherever appropriate.
+> - Don’t include notifications that aren’t related to the user’s current goal.

--- a/components/02-components/messages/02-message-info/README.md
+++ b/components/02-components/messages/02-message-info/README.md
@@ -1,7 +1,10 @@
-Messages keep users informed of important and sometimes time-sensitive changes.
-
 ## When to use
 - The user needs this information, but does not need to take any action. This should be used sparingly, as it interrupts the viewing flow intentionally.
 
-### Resources
-Learn more about accessibility and best practices for alerts from the [U.S. Web Design System](https://designsystem.digital.gov/components/alerts/).
+### Guidance from the [U.S. Web Design System](https://designsystem.digital.gov/components/alerts/)
+> - When the user is required to do something in response to an alert, let them know what they need to do and make that task as easy as possible. Think about how much context to provide with your message. For example, a notification of a system change may require more contextual information than a validation message. Write the message in concise, human readable language; avoid jargon and computer code.
+> - Be polite in error messages — don’t place blame on the user.
+> - Users generally won’t read documentation but will read a message that helps them resolve an error; include some educational material in your error message.
+> - But don’t overdo it — too many notifications will either overwhelm or annoy the user and are likely to be ignored.
+> - Allow a user to dismiss a notification wherever appropriate.
+> - Don’t include notifications that aren’t related to the user’s current goal.

--- a/components/02-components/messages/02-message-info/README.md
+++ b/components/02-components/messages/02-message-info/README.md
@@ -8,3 +8,7 @@
 > - But don’t overdo it — too many notifications will either overwhelm or annoy the user and are likely to be ignored.
 > - Allow a user to dismiss a notification wherever appropriate.
 > - Don’t include notifications that aren’t related to the user’s current goal.
+
+### GitHub issues
+ - [#158: In order to have consistent and easy-to-implement alerts, define alert icon styles](https://github.com/18F/fec-style/issues/158)
+ - [#266: Unify error / info / message styles](https://github.com/18f/fec-style/issues/266)

--- a/components/02-components/messages/03-message-success/README.md
+++ b/components/02-components/messages/03-message-success/README.md
@@ -1,7 +1,10 @@
-Messages keep users informed of important and sometimes time-sensitive changes.
-
 ## When to use
 - The user has taken an action that affirmatively completes. Always help them find what to do next, including confirming their previous action.
 
-### Resources
-Learn more about accessibility and best practices for alerts from the [U.S. Web Design System](https://designsystem.digital.gov/components/alerts/).
+### Guidance from the [U.S. Web Design System](https://designsystem.digital.gov/components/alerts/)
+> - When the user is required to do something in response to an alert, let them know what they need to do and make that task as easy as possible. Think about how much context to provide with your message. For example, a notification of a system change may require more contextual information than a validation message. Write the message in concise, human readable language; avoid jargon and computer code.
+> - Be polite in error messages — don’t place blame on the user.
+> - Users generally won’t read documentation but will read a message that helps them resolve an error; include some educational material in your error message.
+> - But don’t overdo it — too many notifications will either overwhelm or annoy the user and are likely to be ignored.
+> - Allow a user to dismiss a notification wherever appropriate.
+> - Don’t include notifications that aren’t related to the user’s current goal.

--- a/components/02-components/messages/03-message-success/README.md
+++ b/components/02-components/messages/03-message-success/README.md
@@ -8,3 +8,7 @@
 > - But don’t overdo it — too many notifications will either overwhelm or annoy the user and are likely to be ignored.
 > - Allow a user to dismiss a notification wherever appropriate.
 > - Don’t include notifications that aren’t related to the user’s current goal.
+
+### GitHub issues
+ - [#158: In order to have consistent and easy-to-implement alerts, define alert icon styles](https://github.com/18F/fec-style/issues/158)
+ - [#266: Unify error / info / message styles](https://github.com/18f/fec-style/issues/266)

--- a/components/02-components/messages/04-message-alert/README.md
+++ b/components/02-components/messages/04-message-alert/README.md
@@ -11,3 +11,7 @@
 > - But don’t overdo it — too many notifications will either overwhelm or annoy the user and are likely to be ignored.
 > - Allow a user to dismiss a notification wherever appropriate.
 > - Don’t include notifications that aren’t related to the user’s current goal.
+
+### GitHub issues
+ - [#158: In order to have consistent and easy-to-implement alerts, define alert icon styles](https://github.com/18F/fec-style/issues/158)
+ - [#266: Unify error / info / message styles](https://github.com/18f/fec-style/issues/266)

--- a/components/02-components/messages/04-message-alert/README.md
+++ b/components/02-components/messages/04-message-alert/README.md
@@ -1,10 +1,13 @@
-Messages keep users informed of important and sometimes time-sensitive changes.
-
 ## When to use
 - The user has reached a dead end through their navigation—either they’ve entered a search which returns no results, or there is no data available in this entry. Offer users navigational assistance to get them back on the main trail.
 
 ## Guidance
 - Be careful not to treat this like an error. It’s the site that has functioned in an unexpected way, not an error on the user’s part.
 
-### Resources
-Learn more about accessibility and best practices for alerts from the [U.S. Web Design System](https://designsystem.digital.gov/components/alerts/).
+### Guidance from the [U.S. Web Design System](https://designsystem.digital.gov/components/alerts/)
+> - When the user is required to do something in response to an alert, let them know what they need to do and make that task as easy as possible. Think about how much context to provide with your message. For example, a notification of a system change may require more contextual information than a validation message. Write the message in concise, human readable language; avoid jargon and computer code.
+> - Be polite in error messages — don’t place blame on the user.
+> - Users generally won’t read documentation but will read a message that helps them resolve an error; include some educational material in your error message.
+> - But don’t overdo it — too many notifications will either overwhelm or annoy the user and are likely to be ignored.
+> - Allow a user to dismiss a notification wherever appropriate.
+> - Don’t include notifications that aren’t related to the user’s current goal.

--- a/components/02-components/messages/05-message-error/README.md
+++ b/components/02-components/messages/05-message-error/README.md
@@ -1,7 +1,10 @@
-Messages keep users informed of important and sometimes time-sensitive changes.
-
 ## When to use
 - The user has taken an action that the system cannot accept. Always offer guidance to correcting their action.
 
-### Resources
-Learn more about accessibility and best practices for alerts from the [U.S. Web Design System](https://designsystem.digital.gov/components/alerts/).
+### Guidance from the [U.S. Web Design System](https://designsystem.digital.gov/components/alerts/)
+> - When the user is required to do something in response to an alert, let them know what they need to do and make that task as easy as possible. Think about how much context to provide with your message. For example, a notification of a system change may require more contextual information than a validation message. Write the message in concise, human readable language; avoid jargon and computer code.
+> - Be polite in error messages — don’t place blame on the user.
+> - Users generally won’t read documentation but will read a message that helps them resolve an error; include some educational material in your error message.
+> - But don’t overdo it — too many notifications will either overwhelm or annoy the user and are likely to be ignored.
+> - Allow a user to dismiss a notification wherever appropriate.
+> - Don’t include notifications that aren’t related to the user’s current goal.

--- a/components/02-components/messages/05-message-error/README.md
+++ b/components/02-components/messages/05-message-error/README.md
@@ -8,3 +8,7 @@
 > - But don’t overdo it — too many notifications will either overwhelm or annoy the user and are likely to be ignored.
 > - Allow a user to dismiss a notification wherever appropriate.
 > - Don’t include notifications that aren’t related to the user’s current goal.
+
+### GitHub issues
+ - [#158: In order to have consistent and easy-to-implement alerts, define alert icon styles](https://github.com/18F/fec-style/issues/158)
+ - [#266: Unify error / info / message styles](https://github.com/18f/fec-style/issues/266)

--- a/components/02-components/messages/06-message-no-results/README.md
+++ b/components/02-components/messages/06-message-no-results/README.md
@@ -1,7 +1,10 @@
-Messages keep users informed of important and sometimes time-sensitive changes.
-
 ## When to use
 - Use in search results and filtered results lists when the system performed as expected, and the user took the correct, complete set of actions but there was no match. Use targeted buttons so help direct the user to possible next steps.
 
-### Resources
-Learn more about accessibility and best practices for alerts from the [U.S. Web Design System](https://designsystem.digital.gov/components/alerts/).
+### Guidance from the [U.S. Web Design System](https://designsystem.digital.gov/components/alerts/)
+> - When the user is required to do something in response to an alert, let them know what they need to do and make that task as easy as possible. Think about how much context to provide with your message. For example, a notification of a system change may require more contextual information than a validation message. Write the message in concise, human readable language; avoid jargon and computer code.
+> - Be polite in error messages — don’t place blame on the user.
+> - Users generally won’t read documentation but will read a message that helps them resolve an error; include some educational material in your error message.
+> - But don’t overdo it — too many notifications will either overwhelm or annoy the user and are likely to be ignored.
+> - Allow a user to dismiss a notification wherever appropriate.
+> - Don’t include notifications that aren’t related to the user’s current goal.

--- a/components/02-components/secondary-navigation/01-side-navigation/README.md
+++ b/components/02-components/secondary-navigation/01-side-navigation/README.md
@@ -8,10 +8,7 @@ A hierarchical vertical navigation on the left side of a page that helps users n
 ## When to consider something else
 - If you are considering multiple pages, but the content within each page is very short, consider using one medium-longer length page and using an [inpage navigation component](/components/detail/inpage-navigation) instead
 
-## Guidance
-- Indicate where a user is within the navigational hierarchy. Use the “active” state to show users which page they have navigated to.
-- Keep the navigation links short. They can be shorter derivatives of page titles themselves.
-- If the navigation hierarchy is too long, users may miss items at the bottom. If it’s too deep, users may miss items that require too many clicks. Usability test to find the right balance between breadth and depth.
-
-### Resources
-Learn more about accessibility and best practices for side navigations from the [U.S. Web Design System](https://designsystem.digital.gov/components/sidenav/).
+### Guidance from the [U.S. Web Design System](https://designsystem.digital.gov/components/sidenav/)
+> - Indicate where a user is within the navigational hierarchy. Use the “active” state to show users which page they have navigated to.
+> - Keep the navigation links short. They can be shorter derivatives of page titles themselves.
+> - If the navigation hierarchy is too long, users may miss items at the bottom. If it’s too deep, users may miss items that require too many clicks. Usability test to find the right balance between breadth and depth.

--- a/components/02-components/tables/01-simple-table/README.md
+++ b/components/02-components/tables/01-simple-table/README.md
@@ -7,3 +7,6 @@ The `.simple-table--display` modifier class adds vertical rules, alternating bac
 
 ## When to consider something else
 - If you need a row header and a column header, or if you need to present financial data, consider the [custom table component](/components/detail/custom-table)
+
+### GitHub issues
+ - [#111: Adding simple table styles for cms pages](https://github.com/18f/fec-style/issues/111)


### PR DESCRIPTION
## Changes
- Restyles guidance from the U.S. Web Design System 🇺🇸 so that it's more obvious that the guidance has been copied over directly instead of rewritten. It does this by using blockquote styling, and by rewriting the headline.
- Connects TONS of design history to each component by adding GitHub issues to each 🕵️‍♀️ . This should make it easier for future design archeologists to find the history and intention behind research and interaction decisions.

**Before:**
![screen shot 2018-03-28 at 8 05 46 pm](https://user-images.githubusercontent.com/11636908/38062798-e42cf9ce-32c3-11e8-9569-642f02b628f5.png)


**After:**
![screen shot 2018-03-28 at 8 05 16 pm](https://user-images.githubusercontent.com/11636908/38062806-ec0eb380-32c3-11e8-998a-d30a4cf521aa.png)


