### PR TITLE
Add feed component

### DIFF
--- a/components/02-components/feed/01-single-category/README.md
+++ b/components/02-components/feed/01-single-category/README.md
@@ -1,0 +1,12 @@
+Feeds display single posts chronologically, with the most recent posts appearing first. Feeds that show posts from one content category should be visually simple, and eliminate metadata fields that aren’t needed to tell one type of content from another.
+
+## When to use
+- To display a short-medium length list of posts from one content or publication category
+
+## When to consider something else
+- If the list of items is long (more than 7-10) consider using pagination within the feed or another type of interaction altogether
+- If the date of publication is irrelevant to the content or to users' needs, a long feed organized by date may be frustrating. Consider methods that order items by how frequently they are used.
+
+### Examples
+- [Recent advisory opinions issued feed](https://www.fec.gov/data/legal/advisory-opinions/)
+- [Commission directives and policies](https://www.fec.gov/about/leadership-and-structure/)

--- a/components/02-components/feed/01-single-category/single-category.config.json
+++ b/components/02-components/feed/01-single-category/single-category.config.json
@@ -1,0 +1,3 @@
+{
+  "label": "Single category feed"
+}

--- a/components/02-components/feed/01-single-category/single-category.html
+++ b/components/02-components/feed/01-single-category/single-category.html
@@ -1,0 +1,25 @@
+<div class="container" style="padding: 2rem">
+
+  <div class="post-feed">
+
+    <article class="post">
+      <h3><a href="/data/legal/advisory-opinions/2018-01/">AO 2018-01 Libertarian Party of Utah</a></h3>
+      <p class="t-sans">Status as state committee of national party.</p>
+      <p class="t-sans post__doc"><a href="/files/legal/aos/2018-01/AO-2018-01.pdf">Final Opinion | PDF</a></p>
+    </article>
+
+    <article class="post">
+      <h3><a href="/data/legal/advisory-opinions/2017-13/">AO 2017-13 National Sorghum Producers and Sorghum PAC</a></h3>
+      <p class="t-sans">Checkoff system for contributions to trade association and state affiliates acting as collecting agents.</p>
+      <p class="t-sans post__doc"><a href="/files/legal/aos/2017-13/2017-13.pdf">Final Opinion | PDF</a></p>
+    </article>
+
+    <article class="post">
+      <h3><a href="/data/legal/advisory-opinions/2017-12/">AO 2017-12 Take Back Action Fund</a></h3>
+      <p class="t-sans">Application of disclaimer rules to paid Facebook Image and Video ads</p>
+      <p class="t-sans post__doc"><a href="/files/legal/aos/2017-12/2017-12.pdf">Final Opinion | PDF</a></p>
+    </article>
+
+  </div>
+
+</div>

--- a/components/02-components/feed/02-multiple-category/README.md
+++ b/components/02-components/feed/02-multiple-category/README.md
@@ -10,3 +10,7 @@ Feeds display single posts chronologically, with the most recent posts appearing
 ### Examples
 - [Latest updates feed](https://www.fec.gov/updates/)
 - Reports about the FEC: [Strategy, budget and performance category](https://www.fec.gov/about/reports-about-fec/strategy-budget-and-performance/)
+
+### GitHub issues
+ - [#443: Create UX design for "missives" index page](https://github.com/fecgov/fec-cms/issues/443)
+ - [#454: Visual design of Latest Updates index page](https://github.com/fecgov/fec-cms/issues/454)

--- a/components/02-components/feed/02-multiple-category/README.md
+++ b/components/02-components/feed/02-multiple-category/README.md
@@ -1,0 +1,12 @@
+Feeds display single posts chronologically, with the most recent posts appearing first. Feeds that show posts from multiple content categories can display more metadata elements, such as category tags or sub-category labels, which help people identify the differences.
+
+## When to use
+- When users are browsing a list of items from more than one content or publication category, and the most recent content is more likely to be of interest than older items
+- Help users navigate between types of content by providing basic category or keyword filtering
+
+## When to consider something else
+- If the date of publication is irrelevant to the content or to users' needs, a long feed organized by date may be frustrating. Consider methods that order items by how frequently they are used.
+
+### Examples
+- [Latest updates feed](https://www.fec.gov/updates/)
+- Reports about the FEC: [Strategy, budget and performance category](https://www.fec.gov/about/reports-about-fec/strategy-budget-and-performance/)

--- a/components/02-components/feed/02-multiple-category/multiple-category.config.json
+++ b/components/02-components/feed/02-multiple-category/multiple-category.config.json
@@ -1,0 +1,3 @@
+{
+  "label": "Multiple category feed"
+}

--- a/components/02-components/feed/02-multiple-category/multiple-category.html
+++ b/components/02-components/feed/02-multiple-category/multiple-category.html
@@ -1,0 +1,82 @@
+<div class="container" style="padding: 2rem">
+
+  <div class="post-feed">
+    <article class="post">
+      <div class="post__pre">
+        <div class="post__date">March 30, 2018</div>
+      </div>
+      <div class="row">
+        <div class="usa-width-three-fourths">
+          <h3><a href="#">Court remands political committee status case to FEC [<i>CREW, et al. v. FEC</i> (16-2255)]</a></h3>
+          <div class="t-sans row js-post-content">
+            <div class="rich-text">
+              <p>On March 20, 2018, the U.S. District Court for the District of Columbia concluded that the Commission’s dismissal of an administrative complaint Citizens for Responsibility and Ethics in ...<a class="js-read-more post__read-more" href="#">Read more</a></p>
+            </div>
+          </div>
+          <div class="post__meta t-sans">
+            <a class="tag tag--secondary" href="#">FEC Record</a>
+              in: <a href="#">Litigation</a>
+          </div>
+        </div>
+        <div class="usa-width-one-fourth">
+        </div>
+      </div>
+    </article>
+
+    <article class="post">
+      <div class="post__pre">
+        <div class="post__date">March 29, 2018</div>
+      </div>
+      <div class="row">
+        <div class="usa-width-three-fourths">
+          <h3><a href="#">Printed copies of the Corporate/Labor Guide now available for order</a></h3>
+          <div class="t-sans row js-post-content">
+            <div class="rich-text">
+              <p>The FEC’s <a href="#">recently updated</a> <i>Campaign Guide for Corporations and Labor Organizations</i> is now available in print. The Guide contains the most up-to-date information regarding corporations, labor organizations, trade associations ...<a class="js-read-more post__read-more" href="#">Read more</a></p>
+            </div>
+          </div>
+          <div class="post__meta t-sans">
+            <a class="tag tag--secondary" href="#">Tips for treasurers</a>
+          </div>
+        </div>
+        <div class="usa-width-one-fourth">
+        </div>
+      </div>
+    </article>
+
+    <article class="post">
+      <div class="post__pre">
+        <div class="post__date">March 23, 2018</div>
+      </div>
+      <div class="row">
+        <div class="usa-width-three-fourths">
+          <h3><a href="#">Week of March 19 - March 23, 2018</a></h3>
+            <div class="post__meta t-sans">
+              <a class="tag tag--secondary" href="#">Weekly Digest</a>
+            </div>
+        </div>
+      </div>
+    </article>
+
+    <article class="post">
+      <div class="post__pre">
+        <div class="post__date">March 21, 2018</div>
+      </div>
+      <div class="row">
+        <div class="usa-width-three-fourths">
+          <h3><a href="#">April reporting reminder (2018)</a></h3>
+          <div class="t-sans row js-post-content">
+            <div class="rich-text">
+              <p>The following reports are due in April:<a class="js-read-more post__read-more" href="#">Read more</a></p>
+            </div>
+          </div>
+          <div class="post__meta t-sans">
+            <a class="tag tag--secondary" href="#">FEC Record</a>
+              in: <a href="#">Reporting</a>
+          </div>
+        </div>
+      </div>
+    </article>
+  </div>
+
+</div>


### PR DESCRIPTION
## Summary of changes

Adds the existing post component from the site into the pattern library. I've named this component "Feed" instead of "Post" because the feed is what we've been calling a collection of posts.

## Screenshots

![screen shot 2018-03-30 at 11 58 02 am](https://user-images.githubusercontent.com/11636908/38145126-d0439d0c-3415-11e8-8510-77aaf33aefb5.png)
![screen shot 2018-03-30 at 12 06 41 pm](https://user-images.githubusercontent.com/11636908/38145127-d0509700-3415-11e8-9675-5dfef008177a.png)
