### PR TITLE
Removed blue banner component

### DIFF
--- a/components/02-components/banner/banner.html
+++ b/components/02-components/banner/banner.html
@@ -1,6 +1,0 @@
-<div class="banner">
- <div class="container">
-   <span class="t-block t-bold t-centered t-upper">This is a banner</span>
-   <span class="t-block t-centered">More detailed information about this banner.</span>
- </div>
-</div>


### PR DESCRIPTION
## Summary of changes

- Addresses #70 
It was determined that the blue banner component should be removed from the pattern library since this is a unique banner in staging, dev, and feature that would only be used to indicate which environment you are in.