### PR TITLE
Adds color pairing: text and icons section

### DIFF
--- a/components/01-basics/_colors.html
+++ b/components/01-basics/_colors.html
@@ -160,7 +160,7 @@
   <h2>Color pairings: text and icons</h2>
   <p>The colors in this system are used in specific combinations. The background color determines the color of the text, link text, and icons.</p>
 
-  <div class="slab" style="padding: 1rem 0">
+  <div class="slab t-sans" style="padding: 1rem 0">
     <div class="usa-width-one-fourth">
       <span>White backgrounds use black main and accent text, federal blue icon containers, and white icon fills.</span>
     </div>
@@ -200,7 +200,7 @@
     </div>
   </div>
 
-  <div class="slab" style="padding: 1rem 0">
+  <div class="slab t-sans" style="padding: 1rem 0">
     <div class="usa-width-one-fourth">
       <span>Federal blue backgrounds use white main text, aqua accent text, white icon containers, and aqua icon fills.</span>
     </div>
@@ -240,7 +240,7 @@
     </div>
   </div>
 
-  <div class="slab" style="padding: 1rem 0">
+  <div class="slab t-sans" style="padding: 1rem 0">
     <div class="usa-width-one-fourth">
       <span>Crimson backgrounds use white main text, orange accent text, white icon containers, and orange icon fills.</span>
     </div>
@@ -259,7 +259,7 @@
           <span class="card--secondary" style="border: none"><i class="i card__icon i-question-bubble" style="height: 4rem; width: 4rem;"></i></span>
         </div>
       </div>
-      <div class="slab" style="padding-top: 1rem">
+      <div class="slab t-sans" style="padding-top: 1rem">
         <div class="usa-width-one-fourth">
           .crimson<br>
           #631010
@@ -274,13 +274,13 @@
         </div>
         <div class="usa-width-one-fourth">
           background: .inverse<br>
-          image: .inverse
+          image: .orange
         </div>
       </div>
     </div>
   </div>
 
-  <div class="slab" style="padding: 1rem 0">
+  <div class="slab t-sans" style="padding: 1rem 0">
     <div class="usa-width-one-fourth">
       <span>Lightest gray (or neutral) backgrounds use black main and accent text, federal blue icon containers, and white icon fills.</span>
     </div>

--- a/components/01-basics/_colors.html
+++ b/components/01-basics/_colors.html
@@ -157,4 +157,166 @@
     </div>
   </div>
 
+  <h2>Color pairings: text and icons</h2>
+  <p>The colors in this system are used in specific combinations. The background color determines the color of the text, link text, and icons.</p>
+
+  <div class="slab" style="padding: 1rem 0">
+    <div class="usa-width-one-fourth">
+      <span>White backgrounds use black main and accent text, federal blue icon containers, and white icon fills.</span>
+    </div>
+    <div class="usa-width-three-fourths">
+      <div class="slab" style="padding-bottom: 1rem; border: 1px solid #D6D7D9;">
+        <div class="usa-width-one-fourth">
+          &nbsp;
+        </div>
+        <div class="usa-width-one-fourth" style="padding-top: 2rem">
+          <h1>Text</h1>
+        </div>
+        <div class="usa-width-one-fourth" style="padding-top: 4rem">
+          <a href="#">Link text</a>
+        </div>
+        <div class="usa-width-one-fourth" style="padding-top: 1rem">
+          <i class="i i-moving-envelope-circle" style="height: 4rem; width: 4rem;"></i>
+        </div>
+      </div>
+      <div class="slab" style="padding-top: 1rem">
+        <div class="usa-width-one-fourth">
+          .inverse<br>
+          #FFFFFF
+        </div>
+        <div class="usa-width-one-fourth">
+          .base<br>
+          #212121
+        </div>
+        <div class="usa-width-one-fourth">
+          .base<br>
+          #212121
+        </div>
+        <div class="usa-width-one-fourth">
+          background: .federal blue<br>
+          image: .inverse
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="slab" style="padding: 1rem 0">
+    <div class="usa-width-one-fourth">
+      <span>Federal blue backgrounds use white main text, aqua accent text, white icon containers, and aqua icon fills.</span>
+    </div>
+    <div class="usa-width-three-fourths">
+      <div class="slab slab--primary" style="padding-bottom: 1rem">
+        <div class="usa-width-one-fourth">
+          &nbsp;
+        </div>
+        <div class="usa-width-one-fourth" style="padding-top: 2rem">
+          <h1>Text</h1>
+        </div>
+        <div class="usa-width-one-fourth" style="padding-top: 4rem">
+          <a href="#" style="color: #35BDBB; border-bottom-color: #35BDBB">Link text</a>
+        </div>
+        <div class="usa-width-one-fourth" style="padding-top: 1rem">
+          <span class="card--primary" style="border: none"><i class="i card__icon i-elections" style="height: 4rem; width: 4rem; background-size: 2.5rem;"></i></span>
+        </div>
+      </div>
+      <div class="slab" style="padding-top: 1rem">
+        <div class="usa-width-one-fourth">
+          .federal-blue<br>
+          #112E51
+        </div>
+        <div class="usa-width-one-fourth">
+          .inverse<br>
+          #FFFFFF
+        </div>
+        <div class="usa-width-one-fourth">
+          .aqua<br>
+          #35BDBB
+        </div>
+        <div class="usa-width-one-fourth">
+          background: .inverse<br>
+          image: .aqua
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="slab" style="padding: 1rem 0">
+    <div class="usa-width-one-fourth">
+      <span>Crimson backgrounds use white main text, orange accent text, white icon containers, and orange icon fills.</span>
+    </div>
+    <div class="usa-width-three-fourths">
+      <div class="slab slab--secondary" style="padding-bottom: 1rem">
+        <div class="usa-width-one-fourth">
+          &nbsp;
+        </div>
+        <div class="usa-width-one-fourth" style="padding-top: 2rem">
+          <h1>Text</h1>
+        </div>
+        <div class="usa-width-one-fourth" style="padding-top: 4rem">
+          <a href="#" style="color: #F77B42; border-bottom-color: #F77B42">Link text</a>
+        </div>
+        <div class="usa-width-one-fourth" style="padding-top: 1rem">
+          <span class="card--secondary" style="border: none"><i class="i card__icon i-question-bubble" style="height: 4rem; width: 4rem;"></i></span>
+        </div>
+      </div>
+      <div class="slab" style="padding-top: 1rem">
+        <div class="usa-width-one-fourth">
+          .crimson<br>
+          #631010
+        </div>
+        <div class="usa-width-one-fourth">
+          .inverse<br>
+          #FFFFFF
+        </div>
+        <div class="usa-width-one-fourth">
+          .orange<br>
+          #F77B42
+        </div>
+        <div class="usa-width-one-fourth">
+          background: .inverse<br>
+          image: .inverse
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="slab" style="padding: 1rem 0">
+    <div class="usa-width-one-fourth">
+      <span>Lightest gray (or neutral) backgrounds use black main and accent text, federal blue icon containers, and white icon fills.</span>
+    </div>
+    <div class="usa-width-three-fourths">
+      <div class="slab slab--neutral" style="padding-bottom: 1rem">
+        <div class="usa-width-one-fourth">
+          &nbsp;
+        </div>
+        <div class="usa-width-one-fourth" style="padding-top: 2rem">
+          <h1>Text</h1>
+        </div>
+        <div class="usa-width-one-fourth" style="padding-top: 4rem">
+          <a href="#">Link text</a>
+        </div>
+        <div class="usa-width-one-fourth" style="padding-top: 1rem">
+          <i class="i i-moving-envelope-circle" style="height: 4rem; width: 4rem;"></i>
+        </div>
+      </div>
+      <div class="slab" style="padding-top: 1rem">
+        <div class="usa-width-one-fourth">
+          .neutral, .gray-lightest<br>
+          #F1F1F1
+        </div>
+        <div class="usa-width-one-fourth">
+          .base<br>
+          #212121
+        </div>
+        <div class="usa-width-one-fourth">
+          .base<br>
+          #212121
+        </div>
+        <div class="usa-width-one-fourth">
+          background: .federal blue<br>
+          image: .inverse
+        </div>
+      </div>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
This adds color pairings from this issue: https://github.com/fecgov/fec-pattern-library/issues/39

<img width="944" alt="screen shot 2018-04-04 at 11 34 48 pm" src="https://user-images.githubusercontent.com/12799132/38346085-dff19354-3860-11e8-88fe-2c79c758d60a.png">

This PR replaces this old PR https://github.com/fecgov/fec-pattern-library/pull/44. Check old PR for comments that should be fixed in this new PR.