### PR TITLE
Fix links in page template examples

### DIFF
--- a/components/01-basics/_collection-page.html
+++ b/components/01-basics/_collection-page.html
@@ -43,9 +43,9 @@
       </ul>
       <h2 class="u-padding--top">Example pages</h2>
       <ul class="list--bulleted">
-        <li><a href="https://fec.gov/help-candidates-and-committees/registering-candidate/">Registering as a candidate</a></li>
-        <li><a href="https://fec.gov/help-candidates-and-committees/handling-loans-debts-and-advances/">Handling candidate loans, debts and advances</a></li>
-        <li><a href="https://fec.gov/help-candidates-and-committees/filing-reports/">Filing candidate reports</a></li>
+        <li><a target="_blank" href="https://fec.gov/help-candidates-and-committees/registering-candidate/">Registering as a candidate</a></li>
+        <li><a target="_blank" href="https://fec.gov/help-candidates-and-committees/handling-loans-debts-and-advances/">Handling candidate loans, debts and advances</a></li>
+        <li><a target="_blank" href="https://fec.gov/help-candidates-and-committees/filing-reports/">Filing candidate reports</a></li>
       </ul>
 
     </div>

--- a/components/01-basics/_commissioner-page.html
+++ b/components/01-basics/_commissioner-page.html
@@ -76,9 +76,9 @@
       </ul>
       <h2 class="u-padding--top">Example pages</h2>
       <ul class="list--bulleted">
-        <li><a href="https://fec.gov/about/leadership-and-structure/steven-t-walther/">Steven T. Walther</a><br><span class="t-italic">Example of a currently serving commissioner</span></li>
-        <li><a href="https://fec.gov/about/leadership-and-structure/ann-m-ravel/">Ann M. Ravel</a></li>
-        <li><a href="https://fec.gov/about/leadership-and-structure/lee-elliott/">Lee A. Elliott</a></li>
+        <li><a target="_blank" href="https://fec.gov/about/leadership-and-structure/steven-t-walther/">Steven T. Walther</a><br><span class="t-italic">Example of a currently serving commissioner</span></li>
+        <li><a target="_blank" href="https://fec.gov/about/leadership-and-structure/ann-m-ravel/">Ann M. Ravel</a></li>
+        <li><a target="_blank" href="https://fec.gov/about/leadership-and-structure/lee-elliott/">Lee A. Elliott</a></li>
       </ul>
     </div>
 

--- a/components/01-basics/_custom-page.html
+++ b/components/01-basics/_custom-page.html
@@ -45,11 +45,11 @@
       </ul>
       <h2 class="u-padding--top">Example pages</h2>
       <ul class="list--bulleted">
-        <li><a href="https://fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/">Electronic filing overview</a></li>
-        <li><a href="https://fec.gov/help-candidates-and-committees/making-disbursements/travel-behalf-campaigns/">Travel on behalf of campaigns</a><br><span class="t-italic">Guide page showing example text</span></li>
-        <li><a href="https://fec.gov/help-candidates-and-committees/candidate-taking-receipts/contribution-types/">Types of contributions</a><br><span class="t-italic">Guide page showing reporting examples</span></li>
-        <li><a href="https://fec.gov/legal-resources/enforcement/administrative-fines/administrative-fines-file-metadata/">Administrative fines metadata</a></li>
-        <li><a href="https://fec.gov/about/leadership-and-structure/ellen-l-weintraub/documents-related-ogc-enforcement-manual/">Documents related to the OGC Enforcement Manual</a></li>
+        <li><a target="_blank" href="https://fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/">Electronic filing overview</a></li>
+        <li><a target="_blank" href="https://fec.gov/help-candidates-and-committees/making-disbursements/travel-behalf-campaigns/">Travel on behalf of campaigns</a><br><span class="t-italic">Guide page showing example text</span></li>
+        <li><a target="_blank" href="https://fec.gov/help-candidates-and-committees/candidate-taking-receipts/contribution-types/">Types of contributions</a><br><span class="t-italic">Guide page showing reporting examples</span></li>
+        <li><a target="_blank" href="https://fec.gov/legal-resources/enforcement/administrative-fines/administrative-fines-file-metadata/">Administrative fines metadata</a></li>
+        <li><a target="_blank" href="https://fec.gov/about/leadership-and-structure/ellen-l-weintraub/documents-related-ogc-enforcement-manual/">Documents related to the OGC Enforcement Manual</a></li>
       </ul>
 
     </div>

--- a/components/01-basics/_document-feed-page.html
+++ b/components/01-basics/_document-feed-page.html
@@ -23,9 +23,9 @@
       </ul>
       <h2 class="u-padding--top">Example pages</h2>
       <ul class="list--bulleted">
-        <li><a href="https://fec.gov/about/reports-about-fec/strategy-budget-and-performance/">Strategy, budget and performance</a></li>
-        <li><a href="https://fec.gov/about/reports-about-fec/foia-reports/">Freedom of Information Act (FOIA) reports</a></li>
-        <li><a href="https://fec.gov/about/reports-about-fec/annual-and-anniversary-reports/">Annual and anniversary reports</a></li>
+        <li><a target="_blank" href="https://fec.gov/about/reports-about-fec/strategy-budget-and-performance/">Strategy, budget and performance</a></li>
+        <li><a target="_blank" href="https://fec.gov/about/reports-about-fec/foia-reports/">Freedom of Information Act (FOIA) reports</a></li>
+        <li><a target="_blank" href="https://fec.gov/about/reports-about-fec/annual-and-anniversary-reports/">Annual and anniversary reports</a></li>
       </ul>
 
     </div>

--- a/components/01-basics/_meeting-page.html
+++ b/components/01-basics/_meeting-page.html
@@ -47,9 +47,9 @@
       </ul>
       <h2 class="u-padding--top">Example pages</h2>
       <ul class="list--bulleted">
-        <li><a href="https://fec.gov/updates/january-25-2018-open-meeting/">January 25, 2018 open meeting</a></li>
-        <li><a href="https://fec.gov/updates/february-8-2018-audit-hearing/">February 8, 2018 audit hearing</a></li>
-        <li><a href="https://fec.gov/updates/march-6-2018-executive-session/">March 6, 2018 executive session</a></li>
+        <li><a target="_blank" href="https://fec.gov/updates/january-25-2018-open-meeting/">January 25, 2018 open meeting</a></li>
+        <li><a target="_blank" href="https://fec.gov/updates/february-8-2018-audit-hearing/">February 8, 2018 audit hearing</a></li>
+        <li><a target="_blank" href="https://fec.gov/updates/march-6-2018-executive-session/">March 6, 2018 executive session</a></li>
       </ul>
     </div>
 

--- a/components/01-basics/_reporting-example-page.html
+++ b/components/01-basics/_reporting-example-page.html
@@ -33,9 +33,9 @@
       </ul>
       <h2 class="u-padding--top">Example pages</h2>
       <ul class="list--bulleted">
-        <li><a href="https://fec.gov/help-candidates-and-committees/filing-reports/individual-contributions/">How to report individual contributions</a></li>
-        <li><a href="https://fec.gov/help-candidates-and-committees/filing-reports/joint-contributions/">How to report joint contributions</a></li>
-        <li><a href="https://fec.gov/help-candidates-and-committees/filing-reports/in-kind-contributions/">How to report in-kind contributions</a></li>
+        <li><a target="_blank" href="https://fec.gov/help-candidates-and-committees/filing-reports/individual-contributions/">How to report individual contributions</a></li>
+        <li><a target="_blank" href="https://fec.gov/help-candidates-and-committees/filing-reports/joint-contributions/">How to report joint contributions</a></li>
+        <li><a target="_blank" href="https://fec.gov/help-candidates-and-committees/filing-reports/in-kind-contributions/">How to report in-kind contributions</a></li>
       </ul>
     </div>
 

--- a/components/01-basics/_reports-landing-page.html
+++ b/components/01-basics/_reports-landing-page.html
@@ -28,7 +28,7 @@
       </ul>
       <h2 class="u-padding--top">Example pages</h2>
       <ul class="list--bulleted">
-        <li><a href="https://fec.gov/about/reports-about-fec/">Reports about the FEC</a></li>
+        <li><a target="_blank" href="https://fec.gov/about/reports-about-fec/">Reports about the FEC</a></li>
       </ul>
 
     </div>

--- a/components/01-basics/_resource-page.html
+++ b/components/01-basics/_resource-page.html
@@ -63,12 +63,12 @@
       </ul>
       <h2 class="u-padding--top">Example pages</h2>
       <ul class="list--bulleted">
-        <li><a href="https://fec.gov/about/mission-and-history/">Mission and history</a></li>
-        <li><a href="https://fec.gov/about/careers/">Careers</a></li>
-        <li><a href="https://fec.gov/legal-resources/court-cases/">Court cases</a></li>
-        <li><a href="https://fec.gov/legal-resources/regulations/">Regulations</a></li>
-        <li><a href="https://fec.gov/legal-resources/enforcement/complaints-process/">Complaints process</a></li>
-        <li><a href="https://fec.gov/legal-resources/enforcement/administrative-fines/">Administrative fines</a></li>
+        <li><a target="_blank" href="https://fec.gov/about/mission-and-history/">Mission and history</a></li>
+        <li><a target="_blank" href="https://fec.gov/about/careers/">Careers</a></li>
+        <li><a target="_blank" href="https://fec.gov/legal-resources/court-cases/">Court cases</a></li>
+        <li><a target="_blank" href="https://fec.gov/legal-resources/regulations/">Regulations</a></li>
+        <li><a target="_blank" href="https://fec.gov/legal-resources/enforcement/complaints-process/">Complaints process</a></li>
+        <li><a target="_blank" href="https://fec.gov/legal-resources/enforcement/administrative-fines/">Administrative fines</a></li>
       </ul>
     </div>
 

--- a/components/01-basics/_update-pages.html
+++ b/components/01-basics/_update-pages.html
@@ -46,10 +46,10 @@
       <p>Each publication should use its corresponding specific page template.</p>
       <h2 class="u-padding--top">Example pages</h2>
       <ul class="list--bulleted">
-        <li><span class="t-bold">Press release: </span><a target="_blank" href="https://fec.gov/updates/fec-cites-committees-failure-file-12-day-pre-primary-financial-report/">FEC cites committees for failure to file 12-day pre-primary financial report </a></li>
-        <li><span class="t-bold">Record article: </span><a target="_blank" href="https://fec.gov/updates/fec-updates-debt-settlement-and-electioneering-communications-forms/">FEC updates debt settlement and electioneering communications forms </a></li>
-        <li><span class="t-bold">Tips for treasurers: </span><a target="_blank" href="https://fec.gov/updates/its-primary-season-even-unopposed-and-independent-candidates-tip20180227/">It’s primary season, even for unopposed and independent candidates </a></li>
-        <li><span class="t-bold">Weekly digest: </span><a target="_blank" href="https://fec.gov/updates/week-february-march-5-9-2018/">Week of March 5 - 9, 2018 </a></li>
+        <li><a target="_blank" href="https://fec.gov/updates/fec-cites-committees-failure-file-12-day-pre-primary-financial-report/">FEC cites committees for failure to file 12-day pre-primary financial report </a><br><span class="t-italic">Press release</span></li>
+        <li><a target="_blank" href="https://fec.gov/updates/fec-updates-debt-settlement-and-electioneering-communications-forms/">FEC updates debt settlement and electioneering communications forms </a><br><span class="t-italic">Record article</span></li>
+        <li><a target="_blank" href="https://fec.gov/updates/its-primary-season-even-unopposed-and-independent-candidates-tip20180227/">It’s primary season, even for unopposed and independent candidates </a><br><span class="t-italic">Tips for treasurers</span></li>
+        <li><a target="_blank" href="https://fec.gov/updates/week-february-march-5-9-2018/">Week of March 5 - 9, 2018 </a><br><span class="t-italic">Weekly digest</span></li>
       </ul>
     </div>
 

--- a/components/01-basics/_update-pages.html
+++ b/components/01-basics/_update-pages.html
@@ -46,10 +46,10 @@
       <p>Each publication should use its corresponding specific page template.</p>
       <h2 class="u-padding--top">Example pages</h2>
       <ul class="list--bulleted">
-        <li><span class="t-bold">Press release: </span><a href="https://fec.gov/updates/fec-cites-committees-failure-file-12-day-pre-primary-financial-report/">FEC cites committees for failure to file 12-day pre-primary financial report </a></li>
-        <li><span class="t-bold">Record article: </span><a href="https://fec.gov/updates/fec-updates-debt-settlement-and-electioneering-communications-forms/">FEC updates debt settlement and electioneering communications forms </a></li>
-        <li><span class="t-bold">Tips for treasurers: </span><a href="https://fec.gov/updates/its-primary-season-even-unopposed-and-independent-candidates-tip20180227/">It’s primary season, even for unopposed and independent candidates </a></li>
-        <li><span class="t-bold">Weekly digest: </span><a href="https://fec.gov/updates/week-february-march-5-9-2018/">Week of March 5 - 9, 2018 </a></li>
+        <li><span class="t-bold">Press release: </span><a target="_blank" href="https://fec.gov/updates/fec-cites-committees-failure-file-12-day-pre-primary-financial-report/">FEC cites committees for failure to file 12-day pre-primary financial report </a></li>
+        <li><span class="t-bold">Record article: </span><a target="_blank" href="https://fec.gov/updates/fec-updates-debt-settlement-and-electioneering-communications-forms/">FEC updates debt settlement and electioneering communications forms </a></li>
+        <li><span class="t-bold">Tips for treasurers: </span><a target="_blank" href="https://fec.gov/updates/its-primary-season-even-unopposed-and-independent-candidates-tip20180227/">It’s primary season, even for unopposed and independent candidates </a></li>
+        <li><span class="t-bold">Weekly digest: </span><a target="_blank" href="https://fec.gov/updates/week-february-march-5-9-2018/">Week of March 5 - 9, 2018 </a></li>
       </ul>
     </div>
 

--- a/documentation/06-page-layouts/collection-page.md
+++ b/documentation/06-page-layouts/collection-page.md
@@ -2,6 +2,6 @@
   class="Preview-iframe"
   data-role="window"
   src="{{path '/components/preview/{{ _self.handle }}'}}"
-  sandbox="allow-same-origin allow-scripts allow-forms"
+  sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
   marginwidth="0" marginheight="0" frameborder="0" vspace="0" hspace="0" scrolling="yes">
 </iframe>

--- a/documentation/06-page-layouts/commissioner-page.md
+++ b/documentation/06-page-layouts/commissioner-page.md
@@ -2,6 +2,6 @@
   class="Preview-iframe"
   data-role="window"
   src="{{path '/components/preview/{{ _self.handle }}'}}"
-  sandbox="allow-same-origin allow-scripts allow-forms"
+  sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
   marginwidth="0" marginheight="0" frameborder="0" vspace="0" hspace="0" scrolling="yes">
 </iframe>

--- a/documentation/06-page-layouts/custom-page.md
+++ b/documentation/06-page-layouts/custom-page.md
@@ -2,6 +2,6 @@
   class="Preview-iframe"
   data-role="window"
   src="{{path '/components/preview/{{ _self.handle }}'}}"
-  sandbox="allow-same-origin allow-scripts allow-forms"
+  sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
   marginwidth="0" marginheight="0" frameborder="0" vspace="0" hspace="0" scrolling="yes">
 </iframe>

--- a/documentation/06-page-layouts/document-feed-page.md
+++ b/documentation/06-page-layouts/document-feed-page.md
@@ -2,6 +2,6 @@
   class="Preview-iframe"
   data-role="window"
   src="{{path '/components/preview/{{ _self.handle }}'}}"
-  sandbox="allow-same-origin allow-scripts allow-forms"
+  sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
   marginwidth="0" marginheight="0" frameborder="0" vspace="0" hspace="0" scrolling="yes">
 </iframe>

--- a/documentation/06-page-layouts/meeting-page.md
+++ b/documentation/06-page-layouts/meeting-page.md
@@ -2,6 +2,6 @@
   class="Preview-iframe"
   data-role="window"
   src="{{path '/components/preview/{{ _self.handle }}'}}"
-  sandbox="allow-same-origin allow-scripts allow-forms"
+  sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
   marginwidth="0" marginheight="0" frameborder="0" vspace="0" hspace="0" scrolling="yes">
 </iframe>

--- a/documentation/06-page-layouts/reporting-example-page.md
+++ b/documentation/06-page-layouts/reporting-example-page.md
@@ -2,6 +2,6 @@
   class="Preview-iframe"
   data-role="window"
   src="{{path '/components/preview/{{ _self.handle }}'}}"
-  sandbox="allow-same-origin allow-scripts allow-forms"
+  sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
   marginwidth="0" marginheight="0" frameborder="0" vspace="0" hspace="0" scrolling="yes">
 </iframe>

--- a/documentation/06-page-layouts/reports-landing-page.md
+++ b/documentation/06-page-layouts/reports-landing-page.md
@@ -2,6 +2,6 @@
   class="Preview-iframe"
   data-role="window"
   src="{{path '/components/preview/{{ _self.handle }}'}}"
-  sandbox="allow-same-origin allow-scripts allow-forms"
+  sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
   marginwidth="0" marginheight="0" frameborder="0" vspace="0" hspace="0" scrolling="yes">
 </iframe>

--- a/documentation/06-page-layouts/resource-page.md
+++ b/documentation/06-page-layouts/resource-page.md
@@ -2,6 +2,6 @@
   class="Preview-iframe"
   data-role="window"
   src="{{path '/components/preview/{{ _self.handle }}'}}"
-  sandbox="allow-same-origin allow-scripts allow-forms"
+  sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
   marginwidth="0" marginheight="0" frameborder="0" vspace="0" hspace="0" scrolling="yes">
 </iframe>

--- a/documentation/06-page-layouts/update-pages.md
+++ b/documentation/06-page-layouts/update-pages.md
@@ -2,6 +2,6 @@
   class="Preview-iframe"
   data-role="window"
   src="{{path '/components/preview/{{ _self.handle }}'}}"
-  sandbox="allow-same-origin allow-scripts allow-forms"
+  sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
   marginwidth="0" marginheight="0" frameborder="0" vspace="0" hspace="0" scrolling="yes">
 </iframe>


### PR DESCRIPTION
## Summary of changes

- Addresses #106

Previously, the iframe sandbox property would not allow external links to break out of the frame. This 
- Adds the `allow-popups` directive to each iframe sandbox 
- Adds the `target="_blank"` to each link telling it to open in a new tab

that will let the pages open these links in a new browser tab

This PR also includes a change to format the "Update page" example links to be the same format as other links with descriptions.


## Screenshots

**Link behavior**
_not sure why the cursor is huge...sorry!_
![l5tuovqvs7](https://user-images.githubusercontent.com/11636908/38570272-730eeafc-3cbb-11e8-9334-e765bcd94707.gif)



**Link formatting**
_Before_
![screen shot 2018-04-10 at 12 29 01 pm](https://user-images.githubusercontent.com/11636908/38570026-cb41760a-3cba-11e8-9abd-2451fa0ca3ea.png)

_After_
![screen shot 2018-04-10 at 12 28 47 pm](https://user-images.githubusercontent.com/11636908/38570033-ce382264-3cba-11e8-9b89-55e6ee5dd42d.png)
