### PR TITLE
Remove Gemnasium badge - now using Snyk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Dependency Status](https://gemnasium.com/badges/github.com/fecgov/fec-pattern-library.svg)](https://gemnasium.com/github.com/fecgov/fec-pattern-library)
 [![Known Vulnerabilities](https://snyk.io/test/github/fecgov/fec-pattern-library/badge.svg)](https://snyk.io/test/github/fecgov/fec-pattern-library)
 
 # FEC.gov Pattern Library


### PR DESCRIPTION
Remove Gemnasium badge on README.md - now using Snyk to track vulnerabilities
