### PR TITLE
upgrade to jquery 3.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2110,6 +2110,15 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "corejs-typeahead": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/corejs-typeahead/-/corejs-typeahead-1.3.1.tgz",
+      "integrity": "sha512-fyNlBNWJNL6EQUnJyAunEzBzRcwR2cEHtZXBi2pndHPOJ/wpOf3wbS+/Oh+kYYS5sKowQcs0LFwMSl6Y2Xeqkw==",
+      "dev": true,
+      "requires": {
+        "jquery": ">=1.11"
+      }
+    },
     "create-ecdh": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
@@ -2210,6 +2219,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true
+    },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
       "dev": true
     },
     "currently-unhandled": {
@@ -3521,12 +3536,14 @@
         "a11y-dialog": "4.0.0",
         "accessible-mega-menu": "git+https://github.com/noahmanger/Accessible-Mega-Menu.git",
         "ace-builds": "1.2.2",
-        "acorn": "^6.1.0",
+        "acorn": "^6.4.1",
         "aria-accordion": "1.0.0",
         "chroma-js": "1.0.1",
         "colorbrewer": "0.0.2",
         "component-sticky": "1.0.0",
         "concat-stream": "^1.6.2",
+        "corejs-typeahead": "^1.2.1",
+        "css.escape": "^1.5.1",
         "d3": "3.5.5",
         "datatables.net": "1.10.10",
         "datatables.net-responsive": "^2.2.3",
@@ -3537,10 +3554,10 @@
         "eventemitter2": "0.4.14",
         "fullcalendar": "3.3.1",
         "glossary-panel": "1.0.0",
-        "jquery": "^3.4.1",
-        "jquery.inputmask": "3.3.4",
-        "leaflet-providers": "1.1.6",
-        "lodash": "^4.17.11",
+        "jquery": "^3.5.1",
+        "jquery.inputmask": "^3.3.4",
+        "leaflet-providers": "1.8.0 ",
+        "lodash": "^4.17.14",
         "minimatch": "^3.0.4",
         "moment": "2.20.1",
         "numeral": "^1.5.3",
@@ -3556,7 +3573,6 @@
         "topojson": "^3.0.2",
         "tough-cookie": "^2.5.0",
         "tunnel-agent": "^0.6.0",
-        "typeahead.js": "0.11.1",
         "underscore": "^1.8.3"
       },
       "dependencies": {
@@ -7906,9 +7922,9 @@
       }
     },
     "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
     "jquery.inputmask": {
       "version": "3.3.4",
@@ -14424,15 +14440,6 @@
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.15"
-      }
-    },
-    "typeahead.js": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/typeahead.js/-/typeahead.js-0.11.1.tgz",
-      "integrity": "sha1-TmTmcbIjEKhgb0rsgFkkuoSwFbg=",
-      "dev": true,
-      "requires": {
-        "jquery": ">=1.7"
       }
     },
     "typedarray": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "a11y-dialog": "2.3.1",
     "aria-accordion": "^0.1.1",
-    "jquery": "^3.4.1",
+    "jquery": "^3.5.1",
     "jquery.inputmask": "3.3.4",
     "moment": "2.20.1",
     "perfect-scrollbar": "0.6.2"


### PR DESCRIPTION
## Summary

- Resolves #3698 
_Upgrades jquery to 3.5.1 and remediates XSS vulnerabilities._

See jquery docs on what was released for 3.5.1: https://blog.jquery.com/2020/05/04/jquery-3-5-1-released-fixing-a-regression/

## Impacted areas of the application

Upgraded jQuery from 3.4.1 to 3.5.1
modified: ../package-lock.json
modified: ../package.json

## How to test

- `npm i`
- `npm run build`
- `npm run start`
- Spot check pages that use jquery

____
