### PR TITLE
Update cf cli to version 7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
           command: |
             mkdir -p $HOME/bin
             export PATH=$HOME/bin:$PATH
-            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.33.0" | tar xzv -C $HOME/bin
+            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=7.1.0" | tar xzv -C $HOME/bin
             cf install-plugin autopilot -f -r CF-Community
 
       - deploy:

--- a/bin/cf_deploy.sh
+++ b/bin/cf_deploy.sh
@@ -16,13 +16,12 @@ if [[ -z ${org} || -z ${space} || -z ${app} ]]; then
   exit 1
 fi
 
-cf api ${cloud_gov}
-
 (
   set +x # Disable debugging
 
   # Log in if necessary
   if [[ -n ${FEC_CF_USERNAME_DEV} && -n ${FEC_CF_PASSWORD_DEV} ]]; then
+    cf api ${cloud_gov}
     cf auth "${FEC_CF_USERNAME_DEV}" "${FEC_CF_PASSWORD_DEV}"
   fi
 )


### PR DESCRIPTION
## Summary of changes

- Addresses #169

**Deploy task changes:**

- With cf cli version 7, `cf api <endpoint>` logs you out - this is a known issue: https://github.com/cloudfoundry/cli/issues/2075. Only set the endpoint if `deploy` task `--login True` (used for CircleCI)

## Impacted areas of the application

List general components of the application that this PR will affect:

-  Deploys

## Examples

- Example build: https://app.circleci.com/pipelines/github/fecgov/fec-pattern-library/26/workflows/6b254a3b-142a-44e5-9bf1-23273097faa3

## How to test

**Through CircleCI**
- Make your own copy of this branch (please don't commit to this branch)
- Modify the branch here to be your branch name:
https://github.com/fecgov/fec-pattern-library/blob/5abf0a22eceddc851dde5dae8e2315f69c6d7038/.circleci/config.yml#L76-L81
- Push to Github, make sure build works

**Locally:**
- Install cf cli version [following this guide](https://github.com/cloudfoundry/cli/wiki/Version-Switching-Guide) or:
```
# Install cf-cli@7. Complete commands
brew install cf-cli@7

# If you run across an error like this: Error: No such keg: /usr/local/Cellar/cf-cli@6, make sure you install cf-cli version 6 with brew
brew install cf-cli@6
 
# Unlink cf-cli version 6 and link cf-cli version 7
brew unlink cf-cli@6 && brew unlink cf-cli@7 && brew link cf-cli@7 && cf version
```
- Install dependencies with https://github.com/fecgov/fec-pattern-library#installation
- Do a manual deploy with
```
./bin/cf_deploy.sh fec-pattern-library fec-beta-fec dev
```