### PR TITLE
Remove unused autopilot plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,6 @@ jobs:
             mkdir -p $HOME/bin
             export PATH=$HOME/bin:$PATH
             curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=7.1.0" | tar xzv -C $HOME/bin
-            cf install-plugin autopilot -f -r CF-Community
 
       - deploy:
           name: Deploy Pattern Library


### PR DESCRIPTION
## Summary of changes

- Addresses #175 
Remove unused autopilot plugin

One approval requested, thanks!

## How to test

**Through CircleCI**
- Make your own copy of this branch (please don't commit to this branch :))
- Modify the branch on line 81 to be your branch name (`feature/175-remove-autopilot`):
https://github.com/fecgov/fec-pattern-library/blob/5abf0a22eceddc851dde5dae8e2315f69c6d7038/.circleci/config.yml#L76-L81
- Push to Github, make sure build works

