### PR TITLE
188-upgrade moment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "aria-accordion": "^0.1.1",
         "jquery": "^3.5.1",
         "jquery.inputmask": "3.3.4",
-        "moment": "2.20.1",
+        "moment": "2.29.2",
         "perfect-scrollbar": "0.6.2"
       },
       "devDependencies": {
@@ -6246,7 +6246,7 @@
         "leaflet-providers": "1.8.0 ",
         "lodash": "^4.17.19",
         "minimatch": "^3.0.4",
-        "moment": "2.20.1",
+        "moment": "2.29.2",
         "numeral": "^1.5.3",
         "perfect-scrollbar": "0.6.2",
         "prop-types": "^15.7.2",
@@ -10149,9 +10149,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg==",
+      "version": "2.29.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
+      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
       "engines": {
         "node": "*"
       }
@@ -23281,7 +23281,7 @@
         "leaflet-providers": "1.8.0 ",
         "lodash": "^4.17.19",
         "minimatch": "^3.0.4",
-        "moment": "2.20.1",
+        "moment": "2.29.2",
         "numeral": "^1.5.3",
         "perfect-scrollbar": "0.6.2",
         "prop-types": "^15.7.2",
@@ -26511,9 +26511,9 @@
       }
     },
     "moment": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
+      "version": "2.29.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
+      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg=="
     },
     "ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "aria-accordion": "^0.1.1",
     "jquery": "^3.5.1",
     "jquery.inputmask": "3.3.4",
-    "moment": "2.20.1",
+    "moment": "2.29.2",
     "perfect-scrollbar": "0.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Resolves #188 

Upgrades moment to 2.29.2 to fix Directory Traversal vulnerability

### Required reviewers

1-2 devs

## Related PRs

Related PRs against other branches:
FEC-CMS https://github.com/fecgov/fec-cms/pull/5155

## How to test
- Note which versions of Node and npm are currently in use (`nvm ls` and `npm -v`) 
- `nvm use 10.16.0` and `npm i -g npm@6.14.8`
- Pull the branch
- rm -rf node_modules
- npm i
- npm run build 
- npm run start

*Thanks @rfultz for the feedback/improvements of the how to test section! 
