### PR TITLE
192-upgrade moment

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "aria-accordion": "^0.1.1",
     "jquery": "^3.5.1",
     "jquery.inputmask": "3.3.4",
-    "moment": "2.29.2",
+    "moment": "2.29.4",
     "perfect-scrollbar": "0.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary of changes

- Addresses #192 

Upgrades moment to 2.29.4 to fix Regular Expression Denial of Service (ReDoS) 

### Required reviewers

1-2 devs

## How to test
- Note which versions of Node and npm are currently in use (`nvm ls` and `npm -v`) 
- `nvm use 10.16.0` and `npm i -g npm@6.14.8`   (I will put in an issue to upgrade NPM versions because these are no longer compatible with snyk CLI)
- Pull the branch
- rm -rf node_modules
- npm i
- npm run build
- npm run start
