### PR TITLE
upgrade during deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ jobs:
       - run:
           name: Install Node.js Dependencies
           command: |
+            npm upgrade
             npm install
             npm run build
 


### PR DESCRIPTION
## Summary of changes

- Addresses Failed build



This should fix the most recent failed build, so that the CMS is pulled before deployment