### PR TITLE
update nginx file to remove ruby erb

### DIFF
--- a/public/nginx.conf
+++ b/public/nginx.conf
@@ -4,13 +4,13 @@
 worker_processes 1;
 daemon off;
 
-error_log <%= ENV["APP_ROOT"] %>/nginx/logs/error.log;
+error_log ((APP_ROOT))/nginx/logs/error.log;
 events { worker_connections 1024; }
 
 http {
   charset utf-8;
   log_format cloudfoundry '$http_x_forwarded_for - $http_referer - [$time_local] "$request" $status $body_bytes_sent';
-  access_log <%= ENV["APP_ROOT"] %>/nginx/logs/access.log cloudfoundry;
+  access_log ((APP_ROOT))/nginx/logs/access.log cloudfoundry;
   default_type application/octet-stream;
   include mime.types;
   sendfile on;
@@ -31,25 +31,13 @@ http {
   server_tokens off;
 
   server {
-    listen <%= ENV["PORT"] %>;
+    listen ((PORT));
     server_name localhost;
     add_header X-Frame-Options SAMEORIGIN;
 
     location / {
-      root <%= ENV["APP_ROOT"] %>/public;
+      root ((APP_ROOT))/public;
       index index.html index.htm Default.htm;
-      <% if ENV["FORCE_HTTPS"] %>
-        if ($http_x_forwarded_proto != "https") {
-          return 301 https://$host$request_uri;
-        }
-      <% end %>
     }
-
-  <% unless File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_dotfiles")) %>
-    location ~ /\. {
-      deny all;
-      return 404;
-    }
-  <% end %>
   }
 }


### PR DESCRIPTION
## Summary of changes

- Addresses #213

This ticket updates the nginx.conf file to remove ruby erb which is not supported in cflinuxfs4 according to this [PR](https://github.com/cloudfoundry/staticfile-buildpack/pull/360). This resolves the pathing/ frame element issues from removing the nginx.conf file. 

Using our own nginx.conf file with static-buildpack gives us a warning that it is not recommend. We are using our own nginx file to support the frame elements. Eventually we should move over to the nginx-buildpack or remove all of the frame elements. Here is a previous discussion on this [topic](https://github.com/fecgov/fec-proxy/issues/169). I also created a [ticket](https://github.com/fecgov/fec-pattern-library/issues/216) for this issue. 

I tested this by deploying [this](https://app.circleci.com/pipelines/github/fecgov/fec-pattern-library/108/workflows/bd272a8d-7d40-44ed-916a-2e1cdba9207c) test branch. 
