### PR TITLE
upgrade cf cli

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
           command: |
             mkdir -p $HOME/bin
             export PATH=$HOME/bin:$PATH
-            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=7.1.0" | tar xzv -C $HOME/bin
+            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=8.9.0" | tar xzv -C $HOME/bin
 
       - run:
           name: Deploy Pattern Library


### PR DESCRIPTION
## Summary 
The Cloud.gov v2 API for Cloud Foundry is reaching its end-of-life. CF CLI versions 6 and 7 still rely on Cloud Foundry API v2 and will no longer work in coming months with foundations that have disabled it. However, CF CLI v8 no longer uses Cloud Foundry API v2. For more details, refer to this [link](https://github.com/cloudfoundry/community/blob/main/toc/rfc/rfc-0032-cfapiv2-eol.md#impact-and-consequences).

1. circleci/config.yml, is upgraded to use CF CLI v8.9.0. This version supports Cloud Foundry API v3. Deploying to a cloud.gov space should work smoothly with this update

## Resolves # https://github.com/fecgov/openFEC/issues/6110

### Required reviewers

1 developer

## Impacted areas of the application

- install cf cli script
- deploy proxy (to cloud.gov space)


## Screenshots
**Before:**
[cf cli v7.0.1 circleci build](https://app.circleci.com/pipelines/github/fecgov/fec-pattern-library/123/workflows/fa21649f-ab2d-42c2-bc88-edde767043c3/jobs/412):

<img width="1127" alt="Screenshot 2025-01-29 at 4 38 39 PM" src="https://github.com/user-attachments/assets/ddf4c535-7e0d-4d63-8b3d-80f76ea8a2cc" />





## Related PRs


Related PRs against other branches:

- openFEC: https://github.com/fecgov/openFEC/pull/6114
- fec-cms: https://github.com/fecgov/fec-cms/pull/6657
- fec-proxy-redirect: https://github.com/fecgov/fec-proxy-redirect/pull/20
- fec-proxy: https://github.com/fecgov/fec-proxy/pull/416

## How to test
 
- Follow [these](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) instructions to install cf CLI v8 on your local terminal or  run: `brew install cloudfoundry/tap/cf-cli@8`
- verify cf cli version: run `cf version`

```
F612211M:~ pkasireddy$ cf version
cf version 8.9.0+c23186c.2024-12-02
```
- fec-pattern-library has only the master branch. cant test anywhere else except merging this pull request and observe the following in circle build, `Deploy Pattern Library` section: 
- 1. Confirm that fec-pattern-library app is using [Cloud Foundry v3 API](https://v3-apidocs.cloudfoundry.org/version/3.185.0/):

```
API endpoint:   https://api.fr.cloud.gov
API version:    3.185.0
```
<img width="1131" alt="Screenshot 2025-01-29 at 4 38 17 PM" src="https://github.com/user-attachments/assets/1da12045-f921-460a-80ce-666ea97bf7ab" />