### PR TITLE
Icon Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 **package.json**
+
 [![Known Vulnerabilities](https://snyk.io/test/github/fecgov/fec-pattern-library/badge.svg)](https://snyk.io/test/github/fecgov/fec-pattern-library?targetFile=package.json)
 
 # FEC.gov Pattern Library
@@ -8,26 +9,28 @@ This is the collection of styles and design patterns that make up fec.gov. It is
 It is also viewable online at: <https://fec-pattern-library.app.cloud.gov/>
 
 ## Installation
-Make sure you are on the correct Node.js version (Currently version 22.1.0:
-```
+
+Make sure you are on the correct Node.js version (Currently version 22.1.0):
+
+```zsh
 nvm use 22.1.0
 ```
 
 Install dependencies:
 
-```
+```zsh
 npm install
 ```
 
 Build the project
 
-```
+```zsh
 npm run build
 ```
 
 Start the server
 
-```
+```zsh
 npm run start
 ```
 
@@ -35,13 +38,13 @@ npm run start
 
 Build SCSS only:
 
-```
+```zsh
 npm run build-sass
 ```
 
 Build JavaScript only:
 
-```
+```zsh
 npm run build-js
 ```
 
@@ -51,33 +54,39 @@ Since the `fec-cms` repository is a dependency to this pattern library, there ma
 
 If this happens, you may see the following error message in your terminal:
 > Error: File to import not found or unreadable: ./node_modules/fec-cms/fec/fec/static/scss/components/[some-component].
-
+>
 > Parent style sheet: […]/fec-pattern-library/static/scss/styles.scss
 
 If this happens, double-check that things you are trying to import in the pattern library actually exist in `fec-cms`.
-Look in https://github.com/18F/fec-cms/tree/develop/fec/fec/static/scss/components for the component specified by the error message.
+Look in https://github.com/fecgov/fec-cms/tree/develop/fec/fec/static/scss/components for the component specified by the error message.
 If you don’t find the component there, you can safely remove it from `[…]/fec-pattern-library/static/scss/styles.scss` on your branch, then save and execute `npm run build` again. The error message should no longer appear.
 
 ## Front end asset management for components
+
 Component specific SCSS and JavaScript files are contained in the `public/` folder, and compiled files and assets are be served from the `public/` folder.
 
 ### fec-cms git dependency
+
 This repo depends on the `fec-cms` git repo as a local npm package to compile and serve front end assets for components to render correctly. Any updates on `fec-cms` since the initial npm install will require `npm update` to get the latest assets into the `node_modules/fec-cms` folder.
 
 ### SCSS
+
 The Gulp script (`.gulpfile.js`) compiles custom stylesheet of all icons classes (`_icon-classes.scss`) as well as all components as specified in `static/scss/styles.scss`. Any additional layout or component stylesheets created in `fec-cms` must be added to `styles.scss`.
 
 ### JavaScript
-Interactive components that rely on JS will need to have their functions intialized in `static/js/init.js`.
+
+Interactive components that rely on JS will need to have their functions initialized in `static/js/init.js`.
 
 ### Build icons component for documentation
+
 Update the Icons documentation page by running:
 
-```
+```zsh
 npm run build-icons-component
 ```
 
 This command gets a list of icons and generates HTML markup for the custom documentation component. It uses `static/templates/icons-component.html` as a template to fill in the current list of icons from `fec-cms` into `components/01-basics/_icons.html`.
 
 ### "Hack" to get documentation pages to display custom styles
+
 Documentation pages (like `documentation/02-typography.md`) include hardcoded HTML to render hidden components so they can render custom FEC styles. Those components are defined in `components/01-basics/*`.

--- a/components/01-basics/_collection-page.html
+++ b/components/01-basics/_collection-page.html
@@ -43,9 +43,9 @@
       </ul>
       <h2 class="u-padding--top">Example pages</h2>
       <ul class="list--bulleted">
-        <li><a target="_blank" href="https://fec.gov/help-candidates-and-committees/registering-candidate/">Registering as a candidate</a></li>
-        <li><a target="_blank" href="https://fec.gov/help-candidates-and-committees/handling-loans-debts-and-advances/">Handling candidate loans, debts and advances</a></li>
-        <li><a target="_blank" href="https://fec.gov/help-candidates-and-committees/filing-reports/">Filing candidate reports</a></li>
+        <li><a target="_blank" href="https://www.fec.gov/help-candidates-and-committees/registering-candidate/">Registering as a candidate</a></li>
+        <li><a target="_blank" href="https://www.fec.gov/help-candidates-and-committees/handling-loans-debts-and-advances/">Handling candidate loans, debts and advances</a></li>
+        <li><a target="_blank" href="https://www.fec.gov/help-candidates-and-committees/filing-reports/">Filing candidate reports</a></li>
       </ul>
 
     </div>

--- a/components/01-basics/_commissioner-page.html
+++ b/components/01-basics/_commissioner-page.html
@@ -76,9 +76,9 @@
       </ul>
       <h2 class="u-padding--top">Example pages</h2>
       <ul class="list--bulleted">
-        <li><a target="_blank" href="https://fec.gov/about/leadership-and-structure/steven-t-walther/">Steven T. Walther</a><br><span class="t-italic">Example of a currently serving commissioner</span></li>
-        <li><a target="_blank" href="https://fec.gov/about/leadership-and-structure/ann-m-ravel/">Ann M. Ravel</a></li>
-        <li><a target="_blank" href="https://fec.gov/about/leadership-and-structure/lee-elliott/">Lee A. Elliott</a></li>
+        <li><a target="_blank" href="https://www.fec.gov/about/leadership-and-structure/steven-t-walther/">Steven T. Walther</a><br><span class="t-italic">Example of a currently serving commissioner</span></li>
+        <li><a target="_blank" href="https://www.fec.gov/about/leadership-and-structure/ann-m-ravel/">Ann M. Ravel</a></li>
+        <li><a target="_blank" href="https://www.fec.gov/about/leadership-and-structure/lee-elliott/">Lee A. Elliott</a></li>
       </ul>
     </div>
 

--- a/components/01-basics/_custom-page.html
+++ b/components/01-basics/_custom-page.html
@@ -45,11 +45,11 @@
       </ul>
       <h2 class="u-padding--top">Example pages</h2>
       <ul class="list--bulleted">
-        <li><a target="_blank" href="https://fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/">Electronic filing overview</a></li>
-        <li><a target="_blank" href="https://fec.gov/help-candidates-and-committees/making-disbursements/travel-behalf-campaigns/">Travel on behalf of campaigns</a><br><span class="t-italic">Guide page showing example text</span></li>
-        <li><a target="_blank" href="https://fec.gov/help-candidates-and-committees/candidate-taking-receipts/contribution-types/">Types of contributions</a><br><span class="t-italic">Guide page showing reporting examples</span></li>
-        <li><a target="_blank" href="https://fec.gov/legal-resources/enforcement/administrative-fines/administrative-fines-file-metadata/">Administrative fines metadata</a></li>
-        <li><a target="_blank" href="https://fec.gov/about/leadership-and-structure/ellen-l-weintraub/documents-related-ogc-enforcement-manual/">Documents related to the OGC Enforcement Manual</a></li>
+        <li><a target="_blank" href="https://www.fec.gov/help-candidates-and-committees/filing-reports/electronic-filing/">Electronic filing overview</a></li>
+        <li><a target="_blank" href="https://www.fec.gov/help-candidates-and-committees/making-disbursements/travel-behalf-campaigns/">Travel on behalf of campaigns</a><br><span class="t-italic">Guide page showing example text</span></li>
+        <li><a target="_blank" href="https://www.fec.gov/help-candidates-and-committees/candidate-taking-receipts/contribution-types/">Types of contributions</a><br><span class="t-italic">Guide page showing reporting examples</span></li>
+        <li><a target="_blank" href="https://www.fec.gov/legal-resources/enforcement/administrative-fines/administrative-fines-file-metadata/">Administrative fines metadata</a></li>
+        <li><a target="_blank" href="https://www.fec.gov/about/leadership-and-structure/ellen-l-weintraub/documents-related-ogc-enforcement-manual/">Documents related to the OGC Enforcement Manual</a></li>
       </ul>
 
     </div>

--- a/components/01-basics/_document-feed-page.html
+++ b/components/01-basics/_document-feed-page.html
@@ -23,9 +23,9 @@
       </ul>
       <h2 class="u-padding--top">Example pages</h2>
       <ul class="list--bulleted">
-        <li><a target="_blank" href="https://fec.gov/about/reports-about-fec/strategy-budget-and-performance/">Strategy, budget and performance</a></li>
-        <li><a target="_blank" href="https://fec.gov/about/reports-about-fec/foia-reports/">Freedom of Information Act (FOIA) reports</a></li>
-        <li><a target="_blank" href="https://fec.gov/about/reports-about-fec/annual-and-anniversary-reports/">Annual and anniversary reports</a></li>
+        <li><a target="_blank" href="https://www.fec.gov/about/reports-about-fec/strategy-budget-and-performance/">Strategy, budget and performance</a></li>
+        <li><a target="_blank" href="https://www.fec.gov/about/reports-about-fec/foia-reports/">Freedom of Information Act (FOIA) reports</a></li>
+        <li><a target="_blank" href="https://www.fec.gov/about/reports-about-fec/annual-and-anniversary-reports/">Annual and anniversary reports</a></li>
       </ul>
 
     </div>

--- a/components/01-basics/_icons.html
+++ b/components/01-basics/_icons.html
@@ -149,6 +149,11 @@
     </div>
 
     <div class="grid__item">
+      <i class="i i-clipboard-checklist"></i>
+      .i-clipboard-checklist
+    </div>
+
+    <div class="grid__item">
       <i class="i i-clock-reverse"></i>
       .i-clock-reverse
     </div>
@@ -179,6 +184,11 @@
     </div>
 
     <div class="grid__item">
+      <i class="i i-decree"></i>
+      .i-decree
+    </div>
+
+    <div class="grid__item">
       <i class="i i-direction-sign"></i>
       .i-direction-sign
     </div>
@@ -201,6 +211,11 @@
     <div class="grid__item">
       <i class="i i-election"></i>
       .i-election
+    </div>
+
+    <div class="grid__item">
+      <i class="i i-exclamation-bubble"></i>
+      .i-exclamation-bubble
     </div>
 
     <div class="grid__item">
@@ -344,6 +359,11 @@
     </div>
 
     <div class="grid__item">
+      <i class="i i-org-chart"></i>
+      .i-org-chart
+    </div>
+
+    <div class="grid__item">
       <i class="i i-papers"></i>
       .i-papers
     </div>
@@ -396,6 +416,11 @@
     <div class="grid__item">
       <i class="i i-share"></i>
       .i-share
+    </div>
+
+    <div class="grid__item">
+      <i class="i i-shield-scales"></i>
+      .i-shield-scales
     </div>
 
     <div class="grid__item">

--- a/components/01-basics/_icons.html
+++ b/components/01-basics/_icons.html
@@ -64,6 +64,11 @@
     </div>
 
     <div class="grid__item">
+      <i class="i i-arrow-target"></i>
+      .i-arrow-target
+    </div>
+
+    <div class="grid__item">
       <i class="i i-arrow-up-border"></i>
       .i-arrow-up-border
     </div>
@@ -199,11 +204,6 @@
     </div>
 
     <div class="grid__item">
-      <i class="i i-document-example"></i>
-      .i-document-example
-    </div>
-
-    <div class="grid__item">
       <i class="i i-document"></i>
       .i-document
     </div>
@@ -216,6 +216,11 @@
     <div class="grid__item">
       <i class="i i-election"></i>
       .i-election
+    </div>
+
+    <div class="grid__item">
+      <i class="i i-example-document"></i>
+      .i-example-document
     </div>
 
     <div class="grid__item">

--- a/components/01-basics/_icons.html
+++ b/components/01-basics/_icons.html
@@ -199,6 +199,11 @@
     </div>
 
     <div class="grid__item">
+      <i class="i i-document-example"></i>
+      .i-document-example
+    </div>
+
+    <div class="grid__item">
       <i class="i i-document"></i>
       .i-document
     </div>

--- a/components/01-basics/_meeting-page.html
+++ b/components/01-basics/_meeting-page.html
@@ -47,9 +47,9 @@
       </ul>
       <h2 class="u-padding--top">Example pages</h2>
       <ul class="list--bulleted">
-        <li><a target="_blank" href="https://fec.gov/updates/january-25-2018-open-meeting/">January 25, 2018 open meeting</a></li>
-        <li><a target="_blank" href="https://fec.gov/updates/february-8-2018-audit-hearing/">February 8, 2018 audit hearing</a></li>
-        <li><a target="_blank" href="https://fec.gov/updates/march-6-2018-executive-session/">March 6, 2018 executive session</a></li>
+        <li><a target="_blank" href="https://www.fec.gov/updates/january-25-2018-open-meeting/">January 25, 2018 open meeting</a></li>
+        <li><a target="_blank" href="https://www.fec.gov/updates/february-8-2018-audit-hearing/">February 8, 2018 audit hearing</a></li>
+        <li><a target="_blank" href="https://www.fec.gov/updates/march-6-2018-executive-session/">March 6, 2018 executive session</a></li>
       </ul>
     </div>
 

--- a/components/01-basics/_reporting-example-page.html
+++ b/components/01-basics/_reporting-example-page.html
@@ -33,9 +33,9 @@
       </ul>
       <h2 class="u-padding--top">Example pages</h2>
       <ul class="list--bulleted">
-        <li><a target="_blank" href="https://fec.gov/help-candidates-and-committees/filing-reports/individual-contributions/">How to report individual contributions</a></li>
-        <li><a target="_blank" href="https://fec.gov/help-candidates-and-committees/filing-reports/joint-contributions/">How to report joint contributions</a></li>
-        <li><a target="_blank" href="https://fec.gov/help-candidates-and-committees/filing-reports/in-kind-contributions/">How to report in-kind contributions</a></li>
+        <li><a target="_blank" href="https://www.fec.gov/help-candidates-and-committees/filing-reports/individual-contributions/">How to report individual contributions</a></li>
+        <li><a target="_blank" href="https://www.fec.gov/help-candidates-and-committees/filing-reports/joint-contributions/">How to report joint contributions</a></li>
+        <li><a target="_blank" href="https://www.fec.gov/help-candidates-and-committees/filing-reports/in-kind-contributions/">How to report in-kind contributions</a></li>
       </ul>
     </div>
 

--- a/components/01-basics/_reports-landing-page.html
+++ b/components/01-basics/_reports-landing-page.html
@@ -28,7 +28,7 @@
       </ul>
       <h2 class="u-padding--top">Example pages</h2>
       <ul class="list--bulleted">
-        <li><a target="_blank" href="https://fec.gov/about/reports-about-fec/">Reports about the FEC</a></li>
+        <li><a target="_blank" href="https://www.fec.gov/about/reports-about-fec/">Reports about the FEC</a></li>
       </ul>
 
     </div>

--- a/components/01-basics/_resource-page.html
+++ b/components/01-basics/_resource-page.html
@@ -63,12 +63,12 @@
       </ul>
       <h2 class="u-padding--top">Example pages</h2>
       <ul class="list--bulleted">
-        <li><a target="_blank" href="https://fec.gov/about/mission-and-history/">Mission and history</a></li>
-        <li><a target="_blank" href="https://fec.gov/about/careers/">Careers</a></li>
-        <li><a target="_blank" href="https://fec.gov/legal-resources/court-cases/">Court cases</a></li>
-        <li><a target="_blank" href="https://fec.gov/legal-resources/regulations/">Regulations</a></li>
-        <li><a target="_blank" href="https://fec.gov/legal-resources/enforcement/complaints-process/">Complaints process</a></li>
-        <li><a target="_blank" href="https://fec.gov/legal-resources/enforcement/administrative-fines/">Administrative fines</a></li>
+        <li><a target="_blank" href="https://www.fec.gov/about/mission-and-history/">Mission and history</a></li>
+        <li><a target="_blank" href="https://www.fec.gov/about/careers/">Careers</a></li>
+        <li><a target="_blank" href="https://www.fec.gov/legal-resources/court-cases/">Court cases</a></li>
+        <li><a target="_blank" href="https://www.fec.gov/legal-resources/regulations/">Regulations</a></li>
+        <li><a target="_blank" href="https://www.fec.gov/legal-resources/enforcement/complaints-process/">Complaints process</a></li>
+        <li><a target="_blank" href="https://www.fec.gov/legal-resources/enforcement/administrative-fines/">Administrative fines</a></li>
       </ul>
     </div>
 

--- a/components/01-basics/_update-pages.html
+++ b/components/01-basics/_update-pages.html
@@ -46,10 +46,10 @@
       <p>Each publication should use its corresponding specific page template.</p>
       <h2 class="u-padding--top">Example pages</h2>
       <ul class="list--bulleted">
-        <li><a target="_blank" href="https://fec.gov/updates/fec-cites-committees-failure-file-12-day-pre-primary-financial-report/">FEC cites committees for failure to file 12-day pre-primary financial report </a><br><span class="t-italic">Press release</span></li>
-        <li><a target="_blank" href="https://fec.gov/updates/fec-updates-debt-settlement-and-electioneering-communications-forms/">FEC updates debt settlement and electioneering communications forms </a><br><span class="t-italic">Record article</span></li>
-        <li><a target="_blank" href="https://fec.gov/updates/its-primary-season-even-unopposed-and-independent-candidates-tip20180227/">It’s primary season, even for unopposed and independent candidates </a><br><span class="t-italic">Tips for treasurers</span></li>
-        <li><a target="_blank" href="https://fec.gov/updates/week-february-march-5-9-2018/">Week of March 5 - 9, 2018 </a><br><span class="t-italic">Weekly digest</span></li>
+        <li><a target="_blank" href="https://www.fec.gov/updates/fec-cites-committees-failure-file-12-day-pre-primary-financial-report/">FEC cites committees for failure to file 12-day pre-primary financial report </a><br><span class="t-italic">Press release</span></li>
+        <li><a target="_blank" href="https://www.fec.gov/updates/fec-updates-debt-settlement-and-electioneering-communications-forms/">FEC updates debt settlement and electioneering communications forms </a><br><span class="t-italic">Record article</span></li>
+        <li><a target="_blank" href="https://www.fec.gov/updates/its-primary-season-even-unopposed-and-independent-candidates-tip20180227/">It’s primary season, even for unopposed and independent candidates </a><br><span class="t-italic">Tips for treasurers</span></li>
+        <li><a target="_blank" href="https://www.fec.gov/updates/week-february-march-5-9-2018/">Week of March 5 - 9, 2018 </a><br><span class="t-italic">Weekly digest</span></li>
       </ul>
     </div>
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,7 @@ var fs = require('fs-extra');
 var gulp = require('gulp');
 var del = require('del');
 var consolidate = require('gulp-consolidate');
-var sass = require('gulp-dart-sass');
+var sass = require('gulp-sass')(require('sass'));
 var cleanCSS = require('gulp-clean-css');
 var rename = require('gulp-rename');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,8 @@
         "gulp": "^4.0.2",
         "gulp-clean-css": "^3.10.0",
         "gulp-consolidate": "^0.2.0",
-        "gulp-dart-sass": "^1.0.2",
         "gulp-rename": "^1.4.0",
+        "gulp-sass": "^5.1.0",
         "npm-run-all": "^4.1.5",
         "sass": "^1.26.10",
         "snyk": "^1.1105.0",
@@ -7324,93 +7324,6 @@
         "npm": ">=1.2.10"
       }
     },
-    "node_modules/gulp-dart-sass": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/gulp-dart-sass/-/gulp-dart-sass-1.0.2.tgz",
-      "integrity": "sha512-8fLttA824mbuc0jRVlGs00zWYZXBckat6INawx5kp66Eqsz5srNWTA51t0mbfB4C8a/a/GZ9muYLwXGklgAHlw==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^2.3.0",
-        "lodash.clonedeep": "^4.3.2",
-        "plugin-error": "^1.0.1",
-        "replace-ext": "^1.0.0",
-        "sass": "^1.26.3",
-        "strip-ansi": "^4.0.0",
-        "through2": "^2.0.0",
-        "vinyl-sourcemaps-apply": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/gulp-dart-sass/node_modules/ansi-regex": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/gulp-dart-sass/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/gulp-dart-sass/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/gulp-dart-sass/node_modules/replace-ext": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
-      "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/gulp-dart-sass/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/gulp-dart-sass/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/gulp-rename": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.4.0.tgz",
@@ -7418,6 +7331,57 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/gulp-sass": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-5.1.0.tgz",
+      "integrity": "sha512-7VT0uaF+VZCmkNBglfe1b34bxn/AfcssquLKVDYnCDJ3xNBaW7cUuI3p3BQmoKcoKFrs9jdzUxyb+u+NGfL4OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "picocolors": "^1.0.0",
+        "plugin-error": "^1.0.1",
+        "replace-ext": "^2.0.0",
+        "strip-ansi": "^6.0.1",
+        "vinyl-sourcemaps-apply": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gulp-sass/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gulp-sass/node_modules/replace-ext": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-2.0.0.tgz",
+      "integrity": "sha512-UszKE5KVK6JvyD92nzMn9cDapSk6w/CaFZ96CnmDMUqH9oowfxF/ZjRITD25H4DnOQClLA4/j7jLGXXLVKxAug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/gulp-sass/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/gulp/node_modules/camelcase": {
@@ -10510,6 +10474,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "gulp-clean-css": "^3.10.0",
     "gulp-consolidate": "^0.2.0",
     "gulp-rename": "^1.4.0",
-    "gulp-dart-sass": "^1.0.2",
+    "gulp-sass": "^5.1.0",
     "npm-run-all": "^4.1.5",
     "sass": "^1.26.10",
     "snyk": "^1.1105.0",

--- a/static/scss/_icon-classes.scss
+++ b/static/scss/_icon-classes.scss
@@ -76,6 +76,10 @@
   @include u-icon-bg($bang, $primary);
 }
 
+.i-bluesky-circle {
+  @include u-icon-bg($bluesky-circle, $primary);
+}
+
 .i-book {
   @include u-icon-bg($book, $primary);
 }
@@ -174,6 +178,10 @@
 
 .i-election {
   @include u-icon-bg($election, $primary);
+}
+
+.i-example-document {
+  @include u-icon-bg($example-document, $primary);
 }
 
 .i-exclamation-bubble {
@@ -418,6 +426,10 @@
 
 .i-x-circle {
   @include u-icon-bg($x-circle, $primary);
+}
+
+.i-x-twitter-circle {
+  @include u-icon-bg($x-twitter-circle, $primary);
 }
 
 .i-x {


### PR DESCRIPTION
## Summary of changes

- Resolves #150 
- Blocked by https://github.com/fecgov/fec-cms/pull/6709

Adding some missing icons.

In some places, those icons existed on cms but hadn't been added to the pattern library.

In other places, there was some kind of disconnect between www and pattern library; for those to be reflected for approving this PR, the CMS PR must be merged and deployed.

### Required reviewers

- 1 dev
- 1 UX


## Screenshots
Some of the changes (Prod above, localhost below)

<img width="778" alt="image" src="https://github.com/user-attachments/assets/b5a8b313-fdfc-42df-be07-4f4437c322fe" />

## Related PRs

~BLOCKED BY THIS PR~: (It needs to be merged into www Production before building pattern library will accurately reflect the changes

branch | PR
------ | ------
(fec-cms) feature/icon-fixes | [CMS PR 6709](https://github.com/fecgov/fec-cms/pull/6709)

## How to test

- Pull the branch
- delete node_modules, or at least node_modules/fec-cms
- `npm i`
- `npm run build`
- [ ] should be no errors
- `npm run start`
-  [ ] should be no errors
- Check the [icons page](http://localhost:3000/docs/icons)
- [ ] i-arrow-target is correct (the arrow's tail should extend to the outer circumference of the ring instead of clipping well within the ring)
- [ ] i-clipboard-checklist exists
- [ ] i-decree exists
- [ ] i-document-example is gone
- [ ] i-example-document exists
- [ ] i-exclamation-bubble exists
- [ ] i-org-chart exists
- [ ] i-shield-scales exists
- [ ] i-sort-down, i-sort-up, and i-sort are three distinct icons (instead of all three looking the same)
- [ ] i-youtube-circle is correct (i.e. it's their current logo and not the long-retired text lockup)
